### PR TITLE
Fix lost response body on http error responses

### DIFF
--- a/src/main/java/com/java_template/common/auth/Authentication.java
+++ b/src/main/java/com/java_template/common/auth/Authentication.java
@@ -1,19 +1,21 @@
 package com.java_template.common.auth;
 
-import com.java_template.common.config.Config;
 import com.java_template.common.util.SslUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.security.oauth2.client.*;
+import org.springframework.security.oauth2.client.endpoint.RestClientClientCredentialsTokenResponseClient;
+import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
 import org.springframework.stereotype.Service;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
+import org.springframework.web.client.RestClient;
 
 import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,26 +34,6 @@ public class Authentication {
     private static final String CACHE_KEY = "cyoda";
 
     public Authentication() {
-        // Configure SSL context globally for OAuth2 client
-        try {
-            SSLContext sslContext = SslUtils.createSelectiveSSLContext();
-            HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
-
-            // Set hostname verifier for trusted hosts
-            if (Config.SSL_TRUST_ALL || !Config.getTrustedHosts().isEmpty()) {
-                HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> {
-                    if (Config.SSL_TRUST_ALL) {
-                        logger.debug("Trusting hostname {} due to SSL_TRUST_ALL=true", hostname);
-                        return true;
-                    }
-                    return SslUtils.shouldTrustHost(hostname);
-                });
-                logger.info("OAuth2 client configured with custom SSL settings for trusted hosts: {}",
-                        Config.getTrustedHosts());
-            }
-        } catch (Exception e) {
-            logger.error("Failed to configure SSL for OAuth2 client: {}", e.getMessage());
-        }
 
         ClientRegistration registration = ClientRegistration.withRegistrationId("cyoda")
                 .tokenUri(CYODA_API_URL + "/oauth/token")
@@ -64,9 +46,39 @@ public class Authentication {
 
         var registrationRepo = new InMemoryClientRegistrationRepository(registration);
         var clientService = new InMemoryOAuth2AuthorizedClientService(registrationRepo);
-        this.authorizedClientManager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        AuthorizedClientServiceOAuth2AuthorizedClientManager acm = new AuthorizedClientServiceOAuth2AuthorizedClientManager(
                 registrationRepo, clientService
         );
+
+        // We have to inject a different OAuth2AuthorizedClientProvider which is built using RestClientClientCredentialsTokenResponseClient
+        // rather than the deprecated DefaultClientCredentialsTokenResponseClient.
+        // This fixes the issue we were seeing with error responses where the response body was getting lost.
+        // We also inject a custom RestTemplate which uses our custom HttpClient to handle SSL trust.
+        RestClientClientCredentialsTokenResponseClient accessTokenResponseClient = new RestClientClientCredentialsTokenResponseClient();
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(new JdkClientHttpRequestFactory(
+                        SslUtils.createHttpClient()
+                ))
+                .messageConverters((messageConverters) -> {
+                    messageConverters.clear();
+                    messageConverters.add(new FormHttpMessageConverter());
+                    messageConverters.add(new OAuth2AccessTokenResponseHttpMessageConverter());
+                })
+                .defaultStatusHandler(new OAuth2ErrorResponseErrorHandler())
+                .build();
+
+        accessTokenResponseClient.setRestClient(restClient);
+        OAuth2AuthorizedClientProvider acp = OAuth2AuthorizedClientProviderBuilder
+                .builder()
+                .clientCredentials(builder -> {
+                    builder.accessTokenResponseClient(accessTokenResponseClient);
+                })
+                .build();
+
+        acm.setAuthorizedClientProvider(acp);
+
+        this.authorizedClientManager = acm;
     }
 
     /**
@@ -107,17 +119,17 @@ public class Authentication {
     }
 
     /**
-         * Simple container for access token with expiry.
-         */
-        private record CachedToken(OAuth2AccessToken oAuth2AccessToken) {
+     * Simple container for access token with expiry.
+     */
+    private record CachedToken(OAuth2AccessToken oAuth2AccessToken) {
 
         public boolean isValid() {
-                Instant expiresAt = this.oAuth2AccessToken.getExpiresAt();
-                return expiresAt != null && Instant.now().isBefore(expiresAt.minusSeconds(60));
-            }
-
-            public String getTokenValue() {
-                return oAuth2AccessToken.getTokenValue();
-            }
+            Instant expiresAt = this.oAuth2AccessToken.getExpiresAt();
+            return expiresAt != null && Instant.now().isBefore(expiresAt.minusSeconds(60));
         }
+
+        public String getTokenValue() {
+            return oAuth2AccessToken.getTokenValue();
+        }
+    }
 }

--- a/src/main/java/com/java_template/common/auth/Authentication.java
+++ b/src/main/java/com/java_template/common/auth/Authentication.java
@@ -71,9 +71,7 @@ public class Authentication {
         accessTokenResponseClient.setRestClient(restClient);
         OAuth2AuthorizedClientProvider acp = OAuth2AuthorizedClientProviderBuilder
                 .builder()
-                .clientCredentials(builder -> {
-                    builder.accessTokenResponseClient(accessTokenResponseClient);
-                })
+                .clientCredentials(builder -> builder.accessTokenResponseClient(accessTokenResponseClient))
                 .build();
 
         acm.setAuthorizedClientProvider(acp);


### PR DESCRIPTION
I noticed that when http error responses are handled by the Authentication, the response body is lost. This fixes the issue.