### PR TITLE
Fix memory leak in processor criteria caches

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -40,7 +40,7 @@ A structured template for building scalable web clients using **Spring Boot**, d
 
 ## 🛠️ Getting Started
 
-> ☕ **Java 21 Required**  
+> ☕ **Java 21 Required**
 > Make sure Java 21 is installed and set as the active version.
 
 ### 1. Clone the Project
@@ -146,7 +146,7 @@ Domain logic structure. Contains entity structures.
 
 For all methods that require a `technicalId` (such as `updateItem` or `deleteItem`), this field is **automatically included** in the returned entity when using methods like `getItem(...)`, `getItems(...)`, or `getItemsByCondition(...)`.
 
-The `technicalId` represents the internal unique identifier of the entity instance and is required for update or delete operations.  
+The `technicalId` represents the internal unique identifier of the entity instance and is required for update or delete operations.
 It is injected into the resulting `ObjectNode` during data retrieval:
 
 ```java
@@ -429,9 +429,11 @@ public class AddLastModifiedTimestamp implements CyodaProcessor {
     }
 
     @Override
-    public boolean supports(OperationSpecification modelKey) {
-        // Match based on processor name from workflow configuration
-        return "example_function_name".equals(modelKey.operationName());
+    public boolean supports(OperationSpecification opSpec) {
+        // Entity-based processing: check operation name AND model compatibility
+        return "example_function_name".equals(opSpec.operationName()) &&
+               "Pet".equals(opSpec.modelKey().getName()) &&
+               opSpec.modelKey().getVersion() >= 1;
     }
 }
 ```
@@ -563,7 +565,31 @@ To register a processor or criterion:
 3. **Implement the `supports()` method** to define when this component should be used
 4. **Implement the processing method** (`process()` for processors, `check()` for criteria)
 
-> ✅ Component operation names are matched against the `processors[].name` or `criterion.function.name` in workflow configuration via the `supports()` method. The `supports()` method should return `true` when `modelKey.operationName()` matches the expected operation name.
+### `supports()` Method Implementation
+
+The `supports()` method determines when a component should handle a specific operation. Implementation depends on your processing approach:
+
+#### **For JsonNode-based Processing** (JSON payload handling):
+```java
+@Override
+public boolean supports(OperationSpecification opSpec) {
+    // Only check operation name - works with any entity type
+    return "example_function_name".equals(opSpec.operationName());
+}
+```
+
+#### **For Entity-based Processing** (using `toEntity()` or `extractEntity()`):
+```java
+@Override
+public boolean supports(OperationSpecification opSpec) {
+    // Check both operation name AND model compatibility
+    return "example_function_name".equals(opSpec.operationName()) &&
+           "Pet".equals(opSpec.modelKey().getName()) &&
+           opSpec.modelKey().getVersion() >= 1;
+}
+```
+
+> ✅ **Rule**: If your component uses `toEntity(Class)` or `extractEntity(Class)`, you MUST check model name and version compatibility in `supports()`. If you only process JSON payloads, checking operation name is sufficient.
 
 ---
 

--- a/src/main/java/com/java_template/common/workflow/CyodaCriterion.java
+++ b/src/main/java/com/java_template/common/workflow/CyodaCriterion.java
@@ -38,12 +38,15 @@ public interface CyodaCriterion {
     EntityCriteriaCalculationResponse check(CyodaEventContext<EntityCriteriaCalculationRequest> request);
 
     /**
-     * Checks if this criteria checker supports the given model key.
-     * Used to filter criteria checkers based on entity operationName and version
-     * from event metadata before selecting by criteria operationName.
+     * Checks if this criterion supports the given operation specification.
+     * Used by OperationFactory to match criteria to workflow operations based on operation name.
+     * Implementations typically check if opsSpec.operationName() matches the criterion's expected operation name.
+     * Some implementations may also need to check opsSpec.modelKey().getName() and opsSpec.modelKey().getVersion()
+     * when using CriterionSerializer.extractEntity() approach to ensure compatibility with specific entity types and versions.
      *
-     * @param opsSpec the model key containing entity operationName and version
-     * @return true if this criteria checker supports the given model key, false otherwise
+     * @param opsSpec the operation specification containing the operation name from workflow configuration
+     *                and model specification with entity name and version
+     * @return true if this criterion supports the given operation specification, false otherwise
      */
     boolean supports(OperationSpecification opsSpec);
 

--- a/src/main/java/com/java_template/common/workflow/CyodaProcessor.java
+++ b/src/main/java/com/java_template/common/workflow/CyodaProcessor.java
@@ -30,13 +30,16 @@ public interface CyodaProcessor {
     EntityProcessorCalculationResponse process(CyodaEventContext<EntityProcessorCalculationRequest> context);
 
     /**
-     * Checks if this processor supports the given model key.
-     * Used to filter processors based on entity operationName and version
-     * from event metadata before selecting by processor operationName.
+     * Checks if this processor supports the given operation specification.
+     * Used by OperationFactory to match processors to workflow operations based on operation name.
+     * Implementations typically check if opSpec.operationName() matches the processor's expected operation name.
+     * Some implementations may also need to check opSpec.modelKey().getName() and opSpec.modelKey().getVersion()
+     * when using ProcessorSerializer.toEntity() approach to ensure compatibility with specific entity types and versions.
      *
-     * @param modelKey the model key containing entity operationName and version
-     * @return true if this processor supports the given model key, false otherwise
+     * @param opSpec the operation specification containing the operation name from workflow configuration
+     *               and model specification with entity name and version
+     * @return true if this processor supports the given operation specification, false otherwise
      */
-    boolean supports(OperationSpecification modelKey);
+    boolean supports(OperationSpecification opSpec);
 
 }

--- a/src/main/java/com/java_template/common/workflow/OperationSpecification.java
+++ b/src/main/java/com/java_template/common/workflow/OperationSpecification.java
@@ -11,6 +11,7 @@ import org.cyoda.cloud.api.event.processing.EntityCriteriaCalculationRequest;
 import org.cyoda.cloud.api.event.processing.EntityProcessorCalculationRequest;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -59,6 +60,18 @@ public sealed class OperationSpecification
     @JsonProperty("operationName")
     public @NotNull String getOperationName() {
         return operationName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        OperationSpecification that = (OperationSpecification) o;
+        return Objects.equals(modelKey, that.modelKey) && Objects.equals(operationName, that.operationName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelKey, operationName);
     }
 
     /**
@@ -147,6 +160,19 @@ public sealed class OperationSpecification
         public @NotNull String getWorkflowName() {
             return workflowName;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Criterion criterion = (Criterion) o;
+            return Objects.equals(stateName, criterion.stateName) && Objects.equals(transitionName, criterion.transitionName) && Objects.equals(workflowName, criterion.workflowName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), stateName, transitionName, workflowName);
+        }
     }
 
     /**
@@ -219,6 +245,19 @@ public sealed class OperationSpecification
         @JsonProperty("workflowName")
         public @NotNull String getWorkflowName() {
             return workflowName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Processor processor = (Processor) o;
+            return Objects.equals(stateName, processor.stateName) && Objects.equals(transitionName, processor.transitionName) && Objects.equals(workflowName, processor.workflowName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), stateName, transitionName, workflowName);
         }
     }
 

--- a/src/main/java/com/java_template/common/workflow/ops/NoopProcessor.java
+++ b/src/main/java/com/java_template/common/workflow/ops/NoopProcessor.java
@@ -41,8 +41,8 @@ public class NoopProcessor implements CyodaProcessor {
     }
 
     @Override
-    public boolean supports(OperationSpecification modelKey) {
-        return Config.INCLUDE_DEFAULT_OPERATIONS || className.equals(modelKey.operationName());
+    public boolean supports(OperationSpecification opSpec) {
+        return Config.INCLUDE_DEFAULT_OPERATIONS || className.equals(opSpec.operationName());
     }
 
 }


### PR DESCRIPTION
We had the equals and hashcode missing from the OperationSpecification which meant the processorCache and criteriaCache would grow without limit.

Also, an app I had built had a naming conflict, where the same processor name was used for two entities. So I added some better information about taking care to assert the correct model when handling requests with marshalling to entities.