### PR TITLE
refactor: sync common/ framework from CTMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 .gradle
 **/build/
 !src/**/build/
@@ -22,3 +25,14 @@ gradle-app.setting
 
 /.idea/**
 /backup/
+
+.playwright-mcp/
+.kotlin/sessions/
+
+.claude/worktrees
+.claude/settings.local.json
+
+# agent-safehouse local settings
+.sandbox/
+
+application-*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ gradle-app.setting
 .sandbox/
 
 application-*.yml
+
+# Python version manager
+.python-version

--- a/SYNCING_WITH_JAVA_TEMPLATE.md
+++ b/SYNCING_WITH_JAVA_TEMPLATE.md
@@ -1,0 +1,278 @@
+# Syncing the Java Client Template
+
+The `java-client-template` project provides the shared framework layer (`com.java_template.common`) used by Cyoda client applications. This guide describes how to pull improvements made in downstream projects back into the template so all projects benefit.
+
+## What the template owns
+
+### Framework code (canonical home is the template)
+
+| Path (relative to `apps/backend/`) | Description |
+|------|-------------|
+| `src/main/java/com/java_template/common/` | Framework code: auth, config, gRPC, serializer, service, workflow, util, tool, observability, controller, dto, repository, exception |
+| `src/main/kotlin/org/cyoda/uuid/` | UUID utility functions |
+| `src/test/java/com/java_template/common/` | Unit tests for the framework layer |
+| `src/test/java/com/example/` | Example entity, processor, criterion, controller — reference implementation that downstream projects use as a starting point |
+| `src/test/kotlin/org/cyoda/uuid/` | UUID utility tests |
+| `src/test/resources/example/` | Example workflow configs for the reference implementation |
+| `src/main/resources/api/` | OpenAPI specs for Cyoda platform APIs (codegen input) |
+| `src/main/resources/META-INF/` | Spring Boot auto-configuration registrations |
+| `src/main/resources/proto/` | Protobuf definitions for gRPC (CloudEvents, Cyoda Cloud API) |
+
+### Shared config (template provides the structure, apps adapt values)
+
+| Path | Template provides | Apps customize |
+|------|-------------------|----------------|
+| `src/main/resources/schema/` | `common/`, `entity/`, `model/`, `processing/`, `search/` subdirectories | Apps may add schemas (e.g. `common/condition/`, `common/statemachine/conf/`) for jsonschema2pojo types their application code needs |
+| `src/main/resources/logback.xml` | Structure and appenders | `<contextName>` and `{"application":...}` value |
+| `src/main/resources/applicationExample.yml` | Full config template with comments | App name in issuer/key-id fields; app-specific sections added or removed |
+| `build.gradle` | Plugins, codegen config, shared deps | App-specific deps, main class references, app-specific tasks |
+| `src/main/resources/application.yml` | Structure and Cyoda platform config sections | App-specific values, ports, auth config, feature flags |
+
+### Not part of the template (app-specific, never pull)
+
+| Path | Description |
+|------|-------------|
+| `src/main/java/com/<app_package>/application/` | Business logic: controllers, services, entities, processors, criteria, DTOs |
+| `src/main/resources/workflow/` | App entity workflow FSM definitions |
+| `src/main/resources/entity/` | App entity JSON schemas |
+| `src/main/resources/entity-schemas/` | App entity example data |
+| `src/test/java/com/<app_package>/application/` | App-specific unit tests |
+| `src/test/java/e2e/` | App-specific E2E tests |
+| `src/test/resources/features/` | App-specific Gherkin features |
+
+---
+
+## Pulling improvements from a downstream project
+
+When a downstream project improves something in the shared framework layer, those improvements should be pulled into the template.
+
+### Step 1: Evaluate what changed
+
+Before pulling, understand what the downstream project changed and why. Not every change belongs in the template.
+
+**Pull into the template:**
+- Bug fixes in `common/` classes
+- New framework capabilities (new service methods, new utility classes)
+- Performance improvements in shared infrastructure
+- Test coverage improvements for `common/`
+- Schema updates that reflect Cyoda platform API changes
+- OpenAPI spec updates
+- Protobuf definition updates
+- Build plugin or shared dependency version bumps
+
+**Do not pull:**
+- App-specific workarounds (e.g. changing `OboKeyRegistrationService` resource paths to avoid mixing with app workflows)
+- Changes that only make sense in the context of that app's business logic
+- Temporary fixes that should be solved differently in the template
+- Extra schemas that only exist because the app's `application/` code needs them
+
+### Step 2: Diff to understand the delta
+
+```bash
+SOURCE=~/dev/<downstream-project>/apps/backend
+TEMPLATE=apps/backend
+
+# Framework source
+diff -rq $TEMPLATE/src/main/java/com/java_template/common/ \
+         $SOURCE/src/main/java/com/java_template/common/
+
+# Kotlin utilities
+diff -rq $TEMPLATE/src/main/kotlin/ $SOURCE/src/main/kotlin/
+
+# Tests
+diff -rq $TEMPLATE/src/test/java/com/java_template/common/ \
+         $SOURCE/src/test/java/com/java_template/common/
+diff -rq $TEMPLATE/src/test/java/com/example/ \
+         $SOURCE/src/test/java/com/example/
+diff -rq $TEMPLATE/src/test/kotlin/ $SOURCE/src/test/kotlin/
+
+# Resources
+diff -rq $TEMPLATE/src/main/resources/api/ $SOURCE/src/main/resources/api/
+diff -rq $TEMPLATE/src/main/resources/META-INF/ $SOURCE/src/main/resources/META-INF/
+diff -rq $TEMPLATE/src/main/resources/proto/ $SOURCE/src/main/resources/proto/
+diff -rq $TEMPLATE/src/main/resources/schema/ $SOURCE/src/main/resources/schema/
+
+# Build config
+diff $TEMPLATE/build.gradle $SOURCE/build.gradle
+```
+
+Review each difference. Classify it as "template improvement" or "app-specific divergence."
+
+### Step 3: Copy the framework files
+
+For files classified as template improvements, replace wholesale. **Do not merge — replace.**
+
+```bash
+SOURCE=~/dev/<downstream-project>/apps/backend
+TEMPLATE=apps/backend
+
+# Framework source code
+rm -rf $TEMPLATE/src/main/java/com/java_template/common/
+cp -R $SOURCE/src/main/java/com/java_template/common/ \
+      $TEMPLATE/src/main/java/com/java_template/common/
+
+# Kotlin utilities
+rm -rf $TEMPLATE/src/main/kotlin/org/
+cp -R $SOURCE/src/main/kotlin/org/ $TEMPLATE/src/main/kotlin/org/
+
+# Framework tests
+rm -rf $TEMPLATE/src/test/java/com/java_template/common/
+cp -R $SOURCE/src/test/java/com/java_template/common/ \
+      $TEMPLATE/src/test/java/com/java_template/common/
+
+# Example entity tests
+rm -rf $TEMPLATE/src/test/java/com/example/
+cp -R $SOURCE/src/test/java/com/example/ \
+      $TEMPLATE/src/test/java/com/example/
+
+# Kotlin tests
+rm -rf $TEMPLATE/src/test/kotlin/org/
+cp -R $SOURCE/src/test/kotlin/org/ $TEMPLATE/src/test/kotlin/org/
+
+# Example test resources
+rm -rf $TEMPLATE/src/test/resources/example/
+cp -R $SOURCE/src/test/resources/example/ \
+      $TEMPLATE/src/test/resources/example/
+find $TEMPLATE/src/test/resources/example/ -name ".DS_Store" -delete
+
+# OpenAPI specs
+rm -rf $TEMPLATE/src/main/resources/api/
+cp -R $SOURCE/src/main/resources/api/ $TEMPLATE/src/main/resources/api/
+
+# Spring auto-configuration
+rm -rf $TEMPLATE/src/main/resources/META-INF/
+cp -R $SOURCE/src/main/resources/META-INF/ $TEMPLATE/src/main/resources/META-INF/
+
+# Protobuf definitions
+rm -rf $TEMPLATE/src/main/resources/proto/
+cp -R $SOURCE/src/main/resources/proto/ $TEMPLATE/src/main/resources/proto/
+```
+
+### Step 4: Handle schema/ carefully
+
+The downstream project may have added app-specific schemas that do not belong in the template. Conversely, the downstream project may have updated shared schemas.
+
+```bash
+diff -rq $TEMPLATE/src/main/resources/schema/ $SOURCE/src/main/resources/schema/
+```
+
+- **Files in both:** Compare content. If the downstream version is newer/better, take it.
+- **Files only in the source:** Evaluate — is this a shared schema improvement or an app-specific addition? Only copy shared improvements.
+- **Files only in the template:** Keep them — the downstream project may have deleted schemas it doesn't use but other projects do.
+
+**Known app-specific schemas to skip** (these exist in some downstream projects but should not be in the template):
+
+| Schema | Why it exists downstream |
+|--------|------------------------|
+| `common/condition/*.json` | App uses jsonschema2pojo-generated condition types instead of OpenAPI Dto types |
+| `common/statemachine/conf/*.json` | App uses jsonschema2pojo-generated workflow configuration types |
+| `common/ExternalizedFunctionConfig.json` | App-specific jsonschema2pojo type |
+| `common/ScheduledTransitionConfig.json` | App-specific jsonschema2pojo type |
+
+### Step 5: Handle build.gradle
+
+Compare and selectively apply changes:
+
+```bash
+diff $TEMPLATE/build.gradle $SOURCE/build.gradle
+```
+
+**Pull into the template:**
+- Plugin version bumps
+- New shared dependencies used by `common/`
+- Codegen config changes (jsonSchema2Pojo, protobuf, openapi)
+- Source set changes
+- Shared dependency version bumps
+
+**Do not pull:**
+- App-specific `mainClass` references (template uses `com.java_template.Application`)
+- App-specific dependencies (e.g. PDFBox, Trino JDBC)
+- App-specific Gradle tasks
+- Removal of `repositories {}` block (downstream projects may use root `settings.gradle` for this; the template may need it standalone)
+
+### Step 6: Revert app-specific divergences
+
+After copying, check for known app-specific changes that the downstream project made to `common/` files. These should NOT be pulled into the template.
+
+Example from cyoda-test-management-system:
+
+| File | App-specific change | Template should have |
+|------|---------------------|---------------------|
+| `common/auth/OboKeyRegistrationService.java` | Resource paths changed to `/obo-signing-key/workflow.json` | Original paths: `/workflow/v<version>/<entityname>.json` and `/entity-schemas/examples/<EntityName>/` |
+
+After copying, revert these to the template's original convention:
+
+```bash
+git diff $TEMPLATE/src/main/java/com/java_template/common/
+# Review each change — revert app-specific modifications
+```
+
+### Step 7: Compile and test
+
+```bash
+./gradlew :apps:backend:compileJava :apps:backend:compileKotlin
+./gradlew :apps:backend:test
+```
+
+The template has no application code beyond the `com/example/` reference implementation. If the pulled changes compile and the example tests pass, the framework is self-consistent.
+
+If compilation fails, the downstream project introduced a dependency on their application code — that change should not have been pulled. Identify and revert it.
+
+### Step 8: Verify the example project still works
+
+The `com/example/` test suite is the template's integration test. It exercises:
+- Entity creation, retrieval, update
+- Processor execution
+- Criterion evaluation
+- Controller CRUD operations
+- Workflow configuration marshalling
+
+All example tests must pass. If a framework change breaks the example, the example needs updating (this is part of the template, so update it here).
+
+---
+
+## Propagating template updates to downstream projects
+
+After updating the template, downstream projects need to pull the changes. Each downstream project should have its own syncing guide (e.g. `SYNCING_WITH_JAVA_TEMPLATE.md`). The general process for a downstream project:
+
+1. Replace shared directories from the template (same copy commands as above, reversed)
+2. Handle schema/ carefully — keep app-specific schemas, update shared ones
+3. Re-apply any known app-specific divergences
+4. Compile — fix any breakage in application code caused by framework API changes
+5. Run tests — fix any test failures
+6. Align build.gradle shared sections
+
+### Common breakage in downstream projects after a template update
+
+These are the failure patterns we've observed. Document new ones here as they occur.
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `no suitable method found for search(ModelSpec, GroupCondition, ...)` | `EntityService` method signatures changed parameter types | Update application code to use new types (e.g. `GroupCondition` → `GroupConditionDto`) |
+| `incompatible types: String cannot be converted to UUID` | Schema change altered generated class field types | Update application code and tests to use `UUID` |
+| `package X does not exist` | New dependency added in `common/` | Add the dependency to the downstream `build.gradle` |
+| `OboSigningKey workflow file not found on classpath` | OBO bootstrap resources missing | Add `workflow/v1/obosigningkey.json` and `entity-schemas/examples/OboSigningKey/obo-signing-key.json` (or the app's equivalent paths) |
+| CORS validation failure at startup | `CorsProperties.validateSecurityConstraints()` rejects wildcard + credentials | Ensure `allow-credentials` is `false` when using wildcard CORS origins (typically in Docker/K8s) |
+
+---
+
+## Sync verification checklist
+
+After any sync (pull or propagate), verify:
+
+```bash
+# 1. Code generation succeeds
+./gradlew :apps:backend:generateProto \
+          :apps:backend:generateJsonSchema2Pojo \
+          :apps:backend:generateOpenApi
+
+# 2. Compilation succeeds
+./gradlew :apps:backend:compileJava :apps:backend:compileKotlin
+
+# 3. Tests pass
+./gradlew :apps:backend:test
+
+# 4. No stray files
+git status
+find apps/backend/src/ -name ".DS_Store" -delete
+```

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,12 @@ repositories {
     mavenCentral()
 }
 
+// Separate configuration for the OTel Java agent — kept off the compile/runtime classpath
+// so it can be passed as -javaagent (JVM instrumentation), not a classpath entry.
+configurations {
+    otelAgent
+}
+
 sourceSets {
     main {
         java {
@@ -100,6 +106,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web:3.5.3'
     implementation 'org.springframework.boot:spring-boot-starter' // Version managed by Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // Version managed by Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server' // JWT validation; delete when switching to real IdP
     implementation 'org.springframework.boot:spring-boot-starter-validation' // Jakarta validation
     implementation 'org.springframework.data:spring-data-commons' // For Page and Pageable
 
@@ -124,7 +131,15 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
     implementation 'com.fasterxml.uuid:java-uuid-generator:4.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // OpenTelemetry observability — API and annotations only (agent provides SDK at runtime)
+    implementation 'io.opentelemetry:opentelemetry-api:1.44.1'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.11.0'
+    // OTel Java agent — resolved to a file path for -javaagent, not placed on the classpath
+    otelAgent 'io.opentelemetry.javaagent:opentelemetry-javaagent:2.11.0'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
+    // JSON structured logging for ELK/Kubernetes (logback encoder)
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 
     implementation 'com.eaio.uuid:uuid:3.2'
     implementation 'com.beust:jcommander:1.82'
@@ -137,6 +152,8 @@ dependencies {
     testImplementation("io.cucumber:cucumber-junit-platform-engine:7.18.0")
     testImplementation 'org.instancio:instancio-junit:5.5.1'
     testImplementation("org.junit.platform:junit-platform-suite")
+    testImplementation 'io.opentelemetry:opentelemetry-sdk-testing:1.44.1'
+    testImplementation 'org.awaitility:awaitility:4.2.2'
 }
 
 test {
@@ -144,8 +161,11 @@ test {
 
     useJUnitPlatform()
 
-    // Pass system properties to tests (needed for conditional test execution)
+    // Pass system properties to tests (needed for conditional test execution).
+    // Override user.dir so relative File paths in tests resolve against the
+    // subproject directory, not the workspace root where gradlew was invoked.
     systemProperties = System.properties
+    systemProperty 'user.dir', project.projectDir.absolutePath
 }
 
 jsonSchema2Pojo {
@@ -326,6 +346,34 @@ tasks.register('runApp', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     def requestedMain = project.findProperty('mainClass') ?: 'com.java_template.Application'
     mainClass.set(requestedMain.toString())
+    systemProperties = System.properties
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    })
+    // Attach the OTel agent when the observability stack is running locally.
+    // Start the stack first: docker compose -f docker/observability/docker-compose.yml up -d
+    if (project.findProperty('otel') == 'true') {
+        jvmArgs "-javaagent:${configurations.otelAgent.asPath}"
+        environment 'OTEL_SERVICE_NAME', 'java-template-backend'
+        environment 'OTEL_METRICS_EXPORTER', 'prometheus'
+        environment 'OTEL_EXPORTER_PROMETHEUS_PORT', '9464'
+        environment 'OTEL_TRACES_EXPORTER', 'otlp'
+        environment 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'http://localhost:4318'
+        environment 'OTEL_LOGS_EXPORTER', 'none'  // Tempo handles traces only; no log backend in local stack
+        environment 'OTEL_INSTRUMENTATION_GRPC_ENABLED', 'true'
+        environment 'OTEL_INSTRUMENTATION_SPRING_WEB_ENABLED', 'true'
+        environment 'OTEL_INSTRUMENTATION_JDBC_ENABLED', 'true'
+        environment 'OTEL_INSTRUMENTATION_EXECUTOR_ENABLED', 'true'
+    }
+}
+
+tasks.register('runTestApp', JavaExec) {
+    group = 'application'
+    description = 'Run arbitrary test class with Spring Boot context'
+    classpath = sourceSets.test.runtimeClasspath
+    def requestedMain = project.findProperty('mainClass') ?: 'com.java_template.Application'
+    mainClass.set(requestedMain.toString())
+    args = project.findProperty('args')?.toString()?.split(' ') ?: []
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
@@ -343,6 +391,38 @@ tasks.register('validateWorkflowImplementations', JavaExec) {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
+}
+
+tasks.register('validateFunctionalRequirements', JavaExec) {
+    group = 'validation'
+    description = 'Validate that all processors/criteria in requirements are implemented in workflows. Usage: -Pargs="requirements.md workflow.json" (optional)'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass.set('com.java_template.common.tool.FunctionalRequirementsValidator')
+    if (project.hasProperty('args')) {
+        args project.property('args').toString().split(' ')
+    }
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    })
+}
+
+tasks.register('validateWorkflows', JavaExec) {
+    group = 'validation'
+    description = 'Run complete workflow validation suite'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass.set('com.java_template.common.tool.WorkflowValidationSuite')
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    })
+}
+
+// Prints the resolved OTel agent jar path — use this to configure IntelliJ VM options.
+tasks.register('printOtelAgentPath') {
+    group = 'help'
+    description = 'Print the resolved OTel Java agent jar path for use in IDE run configurations'
+    doLast {
+        println configurations.otelAgent.asPath
+    }
 }
 
 

--- a/src/main/java/com/java_template/common/auth/AesGcmEncryption.java
+++ b/src/main/java/com/java_template/common/auth/AesGcmEncryption.java
@@ -1,0 +1,66 @@
+package com.java_template.common.auth;
+
+// ABOUTME: AES-256-GCM encrypt/decrypt for storing RSA private keys in Cyoda entities.
+// Payload format: base64(12-byte IV || GCM ciphertext+tag). No state; all methods static.
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+public class AesGcmEncryption {
+
+    private static final int IV_LENGTH_BYTES = 12;
+    private static final int TAG_LENGTH_BITS = 128;
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private AesGcmEncryption() {}
+
+    public static String encrypt(byte[] plaintext, SecretKey key) {
+        try {
+            byte[] iv = new byte[IV_LENGTH_BYTES];
+            SECURE_RANDOM.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            byte[] ciphertext = cipher.doFinal(plaintext);
+
+            byte[] payload = new byte[IV_LENGTH_BYTES + ciphertext.length];
+            System.arraycopy(iv, 0, payload, 0, IV_LENGTH_BYTES);
+            System.arraycopy(ciphertext, 0, payload, IV_LENGTH_BYTES, ciphertext.length);
+
+            return Base64.getEncoder().encodeToString(payload);
+        } catch (Exception e) {
+            throw new OboTokenException("AES-GCM encryption failed", e);
+        }
+    }
+
+    public static byte[] decrypt(String base64Payload, SecretKey key) {
+        try {
+            byte[] payload = Base64.getDecoder().decode(base64Payload);
+            byte[] iv = Arrays.copyOfRange(payload, 0, IV_LENGTH_BYTES);
+            byte[] ciphertext = Arrays.copyOfRange(payload, IV_LENGTH_BYTES, payload.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            return cipher.doFinal(ciphertext);
+        } catch (OboTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OboTokenException("AES-GCM decryption failed — wrong key or corrupted payload", e);
+        }
+    }
+
+    public static SecretKey decodeKey(String base64Key) {
+        try {
+            byte[] keyBytes = Base64.getDecoder().decode(base64Key);
+            return new SecretKeySpec(keyBytes, "AES");
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to decode AES encryption key", e);
+        }
+    }
+}

--- a/src/main/java/com/java_template/common/auth/AuthClaimsParser.java
+++ b/src/main/java/com/java_template/common/auth/AuthClaimsParser.java
@@ -1,0 +1,36 @@
+package com.java_template.common.auth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility for parsing the role list from a Cyoda {@code authclaims} JSON string.
+ * The key name is mandated by the Cyoda CloudEvents Auth Context Extension spec.
+ */
+public class AuthClaimsParser {
+
+    /** Key mandated by the Cyoda CloudEvents Auth Context Extension specification. */
+    public static final String AUTH_CONTEXT_EXTENSION_ROLES_KEY = "roles";
+
+    private AuthClaimsParser() {}
+
+    /**
+     * Extracts the {@code roles} array from the Cyoda {@code authclaims} JSON attribute.
+     * Returns an empty list if the input is blank, the field is absent, or parsing fails.
+     */
+    public static List<String> parseRoles(ObjectMapper objectMapper, String authClaimsJson) {
+        if (authClaimsJson == null || authClaimsJson.isBlank()) return List.of();
+        try {
+            Map<String, Object> claims = objectMapper.readValue(
+                    authClaimsJson, new TypeReference<>() {});
+            Object roles = claims.get(AUTH_CONTEXT_EXTENSION_ROLES_KEY);
+            if (roles instanceof List<?> list) {
+                return list.stream().map(Object::toString).toList();
+            }
+        } catch (Exception ignored) { }
+        return List.of();
+    }
+}

--- a/src/main/java/com/java_template/common/auth/AuthContextMode.java
+++ b/src/main/java/com/java_template/common/auth/AuthContextMode.java
@@ -1,0 +1,11 @@
+package com.java_template.common.auth;
+
+/**
+ * Controls how the absence of auth context on a CloudEvent is handled during event processing.
+ * REQUIRED fails the event; OPTIONAL warns and falls back to M2M; IGNORE always uses M2M.
+ */
+public enum AuthContextMode {
+    REQUIRED,
+    OPTIONAL,
+    IGNORE
+}

--- a/src/main/java/com/java_template/common/auth/CloudEventAuthContext.java
+++ b/src/main/java/com/java_template/common/auth/CloudEventAuthContext.java
@@ -1,0 +1,17 @@
+package com.java_template.common.auth;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Immutable value object holding auth context attributes from a Cyoda CloudEvent.
+ * Populated from the CloudEvents Auth Context Extension (authtype/authid/authclaims).
+ */
+public record CloudEventAuthContext(
+        String authType,
+        @Nullable String authId,
+        @Nullable String authClaimsJson
+) {
+    public boolean isUserContext() {
+        return "user".equals(authType);
+    }
+}

--- a/src/main/java/com/java_template/common/auth/CloudEventAuthContextExtractor.java
+++ b/src/main/java/com/java_template/common/auth/CloudEventAuthContextExtractor.java
@@ -1,0 +1,30 @@
+package com.java_template.common.auth;
+
+import io.cloudevents.v1.proto.CloudEvent;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Extracts CloudEvents Auth Context Extension attributes from incoming gRPC CloudEvents.
+ * Returns an empty Optional when no auth context attributes are present.
+ */
+@Component
+public class CloudEventAuthContextExtractor {
+
+    private static final String ATTR_AUTHTYPE   = "authtype";
+    private static final String ATTR_AUTHID     = "authid";
+    private static final String ATTR_AUTHCLAIMS = "authclaims";
+
+    public Optional<CloudEventAuthContext> extract(CloudEvent cloudEvent) {
+        var attrs = cloudEvent.getAttributesMap();
+        if (!attrs.containsKey(ATTR_AUTHTYPE)) {
+            return Optional.empty();
+        }
+        String authType   = attrs.get(ATTR_AUTHTYPE).getCeString();
+        String authId     = attrs.containsKey(ATTR_AUTHID) ? attrs.get(ATTR_AUTHID).getCeString() : null;
+        String authClaims = attrs.containsKey(ATTR_AUTHCLAIMS) ? attrs.get(ATTR_AUTHCLAIMS).getCeString() : null;
+
+        return Optional.of(new CloudEventAuthContext(authType, authId, authClaims));
+    }
+}

--- a/src/main/java/com/java_template/common/auth/DefaultEventUserResolver.java
+++ b/src/main/java/com/java_template/common/auth/DefaultEventUserResolver.java
@@ -1,0 +1,40 @@
+package com.java_template.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Default {@link EventUserResolver} used in java_template environments where no application-specific
+ * resolver is registered. Trusts authid and authclaims without any database verification.
+ * In production, this bean is replaced by an application-layer implementation.
+ */
+@Component
+@ConditionalOnMissingBean(value = EventUserResolver.class, ignored = DefaultEventUserResolver.class)
+public class DefaultEventUserResolver implements EventUserResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultEventUserResolver.class);
+
+    private final ObjectMapper objectMapper;
+
+    public DefaultEventUserResolver(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public EventUserIdentity resolve(CloudEventAuthContext authContext) {
+        String authId = authContext.authId();
+        if (authId == null || authId.isBlank()) {
+            throw new EventUserResolutionException(
+                    "Cannot resolve user: authtype=user but authid attribute is absent");
+        }
+        logger.warn("DefaultEventUserResolver: trusting authid='{}' without user verification " +
+                "(no application EventUserResolver bean is registered)", authId);
+        List<String> roles = AuthClaimsParser.parseRoles(objectMapper, authContext.authClaimsJson());
+        return new EventUserIdentity(authId, roles);
+    }
+}

--- a/src/main/java/com/java_template/common/auth/EventAuthContextHandler.java
+++ b/src/main/java/com/java_template/common/auth/EventAuthContextHandler.java
@@ -1,0 +1,119 @@
+package com.java_template.common.auth;
+
+import io.cloudevents.v1.proto.CloudEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Establishes the correct SecurityContext for a CloudEvent processing thread based on the
+ * CloudEvents Auth Context Extension. Delegates user resolution and verification to the
+ * injected {@link EventUserResolver} bean, then installs a synthetic {@link JwtAuthenticationToken}
+ * so that {@code OboAwareAuthentication} performs OBO for all downstream Cyoda calls (gRPC and HTTP).
+ */
+@Service
+@EnableConfigurationProperties(EventAuthContextProperties.class)
+public class EventAuthContextHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventAuthContextHandler.class);
+
+    private final EventAuthContextProperties properties;
+    private final CloudEventAuthContextExtractor extractor;
+    private final EventUserResolver userResolver;
+    private final OboProperties oboProperties;
+
+    public EventAuthContextHandler(
+            EventAuthContextProperties properties,
+            CloudEventAuthContextExtractor extractor,
+            EventUserResolver userResolver,
+            OboProperties oboProperties
+    ) {
+        this.properties = properties;
+        this.extractor = extractor;
+        this.userResolver = userResolver;
+        this.oboProperties = oboProperties;
+    }
+
+    /**
+     * Establishes the SecurityContext appropriate for this CloudEvent and returns a scope
+     * that restores the previous context on close. Use in try-with-resources.
+     *
+     * @throws EventAuthContextMissingException if auth context is absent and mode is REQUIRED
+     * @throws EventUserResolutionException     if authtype=user but resolver fails
+     */
+    public EventAuthContextScope establish(CloudEvent cloudEvent) {
+        SecurityContext previous = SecurityContextHolder.getContext();
+
+        if (properties.getMode() == AuthContextMode.IGNORE) {
+            SecurityContextHolder.clearContext();
+            return new EventAuthContextScope(previous);
+        }
+
+        Optional<CloudEventAuthContext> maybeCtx = extractor.extract(cloudEvent);
+
+        if (maybeCtx.isEmpty()) {
+            handleAbsent();
+            return new EventAuthContextScope(previous);
+        }
+
+        handlePresent(maybeCtx.get());
+        return new EventAuthContextScope(previous);
+    }
+
+    private void handleAbsent() {
+        switch (properties.getMode()) {
+            case REQUIRED -> throw new EventAuthContextMissingException(
+                    "CloudEvent auth context is required (mode=REQUIRED) but absent");
+            case OPTIONAL -> {
+                logger.warn("CloudEvent carries no auth context — falling back to M2M (mode=OPTIONAL)");
+                SecurityContextHolder.clearContext();
+            }
+            default -> SecurityContextHolder.clearContext();
+        }
+    }
+
+    private void handlePresent(CloudEventAuthContext ctx) {
+        if (!ctx.isUserContext()) {
+            logger.debug("CloudEvent auth context authtype='{}' — using M2M", ctx.authType());
+            SecurityContextHolder.clearContext();
+            return;
+        }
+
+        // Explicitly clear context before calling the resolver so that any Cyoda lookups
+        // inside resolve() use the M2M service account.
+        SecurityContextHolder.clearContext();
+
+        logger.debug("CloudEvent auth context authtype='user', authid='{}' — resolving user", ctx.authId());
+        EventUserIdentity identity = userResolver.resolve(ctx);
+
+        SecurityContextHolder.setContext(buildSecurityContext(identity));
+        logger.debug("Switched SecurityContext to user '{}' for event processing", identity.userId());
+    }
+
+    private SecurityContext buildSecurityContext(EventUserIdentity identity) {
+        // Build a synthetic Jwt recognised by OboAwareAuthentication.
+        // - "sub" claim carries the user UUID used by OboTokenService as the cache key and subject token sub
+        // - The roles claim name matches oboProperties.getRolesClaimName() (what OboAwareAuthentication reads)
+        // The token value is a non-secret placeholder; it is never validated as a real JWT.
+        Jwt jwt = Jwt.withTokenValue("event-auth-context-synthetic")
+                .header("alg", "none")
+                .subject(identity.userId())
+                .claim(oboProperties.getRolesClaimName(), identity.roles())
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .build();
+
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(auth);
+        return ctx;
+    }
+}

--- a/src/main/java/com/java_template/common/auth/EventAuthContextMissingException.java
+++ b/src/main/java/com/java_template/common/auth/EventAuthContextMissingException.java
@@ -1,0 +1,9 @@
+package com.java_template.common.auth;
+
+/**
+ * Thrown when a CloudEvent carries no auth context and auth-context mode is REQUIRED.
+ * Signals that the event cannot be processed and must return an error response.
+ */
+public class EventAuthContextMissingException extends RuntimeException {
+    public EventAuthContextMissingException(String message) { super(message); }
+}

--- a/src/main/java/com/java_template/common/auth/EventAuthContextProperties.java
+++ b/src/main/java/com/java_template/common/auth/EventAuthContextProperties.java
@@ -1,0 +1,16 @@
+package com.java_template.common.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for CloudEvent auth context handling.
+ * Bound to {@code app.event.auth-context.*} in application.yml.
+ */
+@ConfigurationProperties(prefix = "app.event.auth-context")
+public class EventAuthContextProperties {
+
+    private AuthContextMode mode = AuthContextMode.REQUIRED;
+
+    public AuthContextMode getMode() { return mode; }
+    public void setMode(AuthContextMode mode) { this.mode = mode; }
+}

--- a/src/main/java/com/java_template/common/auth/EventAuthContextScope.java
+++ b/src/main/java/com/java_template/common/auth/EventAuthContextScope.java
@@ -1,0 +1,22 @@
+package com.java_template.common.auth;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * AutoCloseable scope that restores the SecurityContext captured before event auth context
+ * was established. Intended for try-with-resources use in AbstractEventStrategy.
+ */
+public class EventAuthContextScope implements AutoCloseable {
+
+    private final SecurityContext previousContext;
+
+    EventAuthContextScope(SecurityContext previousContext) {
+        this.previousContext = previousContext;
+    }
+
+    @Override
+    public void close() {
+        SecurityContextHolder.setContext(previousContext);
+    }
+}

--- a/src/main/java/com/java_template/common/auth/EventUserIdentity.java
+++ b/src/main/java/com/java_template/common/auth/EventUserIdentity.java
@@ -1,0 +1,13 @@
+package com.java_template.common.auth;
+
+import java.util.List;
+
+/**
+ * Resolved user identity returned by {@link EventUserResolver} for CloudEvent auth context processing.
+ * Carries the user UUID and their roles for subsequent OBO token exchange.
+ * Roles must not carry a {@code ROLE_} prefix — {@code OboAwareAuthentication} strips it, making stripping idempotent.
+ */
+public record EventUserIdentity(
+        String userId,
+        List<String> roles
+) {}

--- a/src/main/java/com/java_template/common/auth/EventUserResolutionException.java
+++ b/src/main/java/com/java_template/common/auth/EventUserResolutionException.java
@@ -1,0 +1,10 @@
+package com.java_template.common.auth;
+
+/**
+ * Thrown when a CloudEvent auth context user cannot be resolved, does not exist,
+ * or fails an application-level permission check. Triggers an error response to Cyoda.
+ */
+public class EventUserResolutionException extends RuntimeException {
+    public EventUserResolutionException(String message) { super(message); }
+    public EventUserResolutionException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/com/java_template/common/auth/EventUserResolver.java
+++ b/src/main/java/com/java_template/common/auth/EventUserResolver.java
@@ -1,0 +1,23 @@
+package com.java_template.common.auth;
+
+/**
+ * Extension point for resolving and verifying user identity from a CloudEvent auth context.
+ * Implementations are provided by the application layer and may enforce user existence,
+ * role checks, and permission validation appropriate to the domain.
+ *
+ * <p>The {@code SecurityContextHolder} is empty when {@code resolve()} is called — any
+ * Cyoda calls inside the implementation use the M2M service account automatically.
+ */
+public interface EventUserResolver {
+
+    /**
+     * Resolves and verifies the user identity described by the auth context.
+     * Only called when {@code authContext.isUserContext()} is {@code true}.
+     *
+     * @param authContext the CloudEvent auth context
+     * @return resolved identity (userId + roles)
+     * @throws EventUserResolutionException if the user cannot be found, is not authorised,
+     *                                      or any application-level check fails
+     */
+    EventUserIdentity resolve(CloudEventAuthContext authContext);
+}

--- a/src/main/java/com/java_template/common/auth/OboAwareAuthentication.java
+++ b/src/main/java/com/java_template/common/auth/OboAwareAuthentication.java
@@ -1,0 +1,73 @@
+package com.java_template.common.auth;
+
+// ABOUTME: OBO-aware token provider that enforces user identity propagation to Cyoda.
+// When a user JWT is in the SecurityContext, OBO is mandatory and fails loudly on error.
+// M2M is used only when the SecurityContext holds no user (infrastructure/background paths).
+
+import com.java_template.common.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Primary
+@EnableConfigurationProperties(OboProperties.class)
+public class OboAwareAuthentication extends Authentication {
+
+    private static final Logger logger = LoggerFactory.getLogger(OboAwareAuthentication.class);
+
+    private final OboProperties oboProperties;
+    private final OboTokenService oboTokenService;
+
+    public OboAwareAuthentication(Config config, OboProperties oboProperties, OboTokenService oboTokenService) {
+        super(config);
+        this.oboProperties = oboProperties;
+        this.oboTokenService = oboTokenService;
+    }
+
+    @Override
+    public OAuth2AccessToken getAccessToken() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof JwtAuthenticationToken jwt) {
+            return getOboTokenOrThrow(jwt);
+        }
+        logger.trace("No user context on current thread — using M2M service account token");
+        return super.getAccessToken();
+    }
+
+    private OAuth2AccessToken getOboTokenOrThrow(JwtAuthenticationToken jwt) {
+        if (!oboProperties.isEnabled()) {
+            throw new OboTokenException(
+                    "OBO token exchange is not configured. "
+                            + "No encryption key found via app.obo.encryption-key property or "
+                            + "app.obo.encryption-key-file. Cannot execute a user-attributed Cyoda call.");
+        }
+
+        String sub = jwt.getToken().getClaimAsString("sub");
+        if (sub == null || sub.isBlank()) {
+            throw new OboTokenException("Cannot perform OBO exchange: JWT has no 'sub' claim");
+        }
+
+        List<String> rawRoles = jwt.getToken().getClaimAsStringList(oboProperties.getRolesClaimName());
+        List<String> userRoles = stripRolePrefix(rawRoles);
+
+        return oboTokenService.getOboToken(sub, userRoles)
+                .orElseThrow(() -> new OboTokenException(
+                        "OBO token exchange failed for user " + sub +
+                        ". See logs for exchange error details."));
+    }
+
+    private static List<String> stripRolePrefix(List<String> roles) {
+        if (roles == null) return List.of();
+        return roles.stream()
+                .map(r -> r.startsWith("ROLE_") ? r.substring(5) : r)
+                .toList();
+    }
+}

--- a/src/main/java/com/java_template/common/auth/OboKeyRegistrationService.java
+++ b/src/main/java/com/java_template/common/auth/OboKeyRegistrationService.java
@@ -1,0 +1,467 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Manages the OBO signing key lifecycle: entity-based encrypted key storage,
+// idempotent Cyoda registration, and proactive rotation with a configurable grace period.
+
+import com.java_template.common.config.Config;
+import com.java_template.common.dto.EntityWithMetadata;
+import com.java_template.common.service.EntityService;
+import com.java_template.common.util.SslUtils;
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import jakarta.annotation.PostConstruct;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class OboKeyRegistrationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(OboKeyRegistrationService.class);
+
+    private final OboProperties oboProperties;
+    private final SubjectTokenSigner subjectTokenSigner;
+    private final Authentication authentication;
+    private final EntityService entityService;
+    private final Config config;
+    private final RestClient restClient;
+
+    public OboKeyRegistrationService(OboProperties oboProperties,
+                                     SubjectTokenSigner subjectTokenSigner,
+                                     Authentication authentication,
+                                     EntityService entityService,
+                                     Config config) {
+        this.oboProperties = oboProperties;
+        this.subjectTokenSigner = subjectTokenSigner;
+        this.authentication = authentication;
+        this.entityService = entityService;
+        this.config = config;
+        this.restClient = RestClient.builder()
+                .requestFactory(new JdkClientHttpRequestFactory(SslUtils.createHttpClient(config)))
+                .build();
+    }
+
+    @PostConstruct
+    public void onStartup() {
+        if (!oboProperties.isEnabled()) {
+            logger.warn("OBO is not configured — no encryption key found via property or file. "
+                    + "Set app.obo.encryption-key or provide a key file at app.obo.encryption-key-file. "
+                    + "Skipping key setup.");
+            return;
+        }
+        checkAndEnsureKeyRegistered();
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void scheduledCheck() {
+        if (!oboProperties.isEnabled()) return;
+        checkAndEnsureKeyRegistered();
+    }
+
+    private void checkAndEnsureKeyRegistered() {
+        // Ensure all Cyoda calls (gRPC and HTTP) within this method use the M2M
+        // service-account token for app.config.cyoda-client-id. Startup and scheduler
+        // threads carry an empty SecurityContext by default, but we make it explicit
+        // so that OboAwareAuthentication always takes the M2M path rather than
+        // accidentally entering the OBO path if anything was placed on the thread.
+        SecurityContext previous = SecurityContextHolder.getContext();
+        SecurityContextHolder.clearContext();
+        try {
+            String resolvedKey = oboProperties.resolveEncryptionKey();
+            if (resolvedKey == null) {
+                throw new OboTokenException(
+                        "OBO encryption key could not be resolved from property or file. "
+                        + "Set app.obo.encryption-key or ensure a readable file at app.obo.encryption-key-file.");
+            }
+            SecretKey aesKey = AesGcmEncryption.decodeKey(resolvedKey);
+
+            String caasOrgId = fetchCaasOrgId();
+            subjectTokenSigner.setActiveCaasOrgId(caasOrgId);
+            logger.info("caas_org_id fetched from Cyoda: {}", caasOrgId);
+
+            ensureEntityModelRegistered();
+
+            List<EntityWithMetadata<OboSigningKey>> entities =
+                    entityService.findAll(OboSigningKey.MODEL_SPEC, OboSigningKey.class).data();
+
+            if (entities == null || entities.isEmpty()) {
+                logger.info("No OboSigningKey entity found — bootstrapping new key pair");
+                bootstrapNewKey(aesKey);
+                return;
+            }
+
+            EntityWithMetadata<OboSigningKey> entityWithMetadata = entities.getFirst();
+            OboSigningKey signingKey = entityWithMetadata.entity();
+
+            RSAPrivateKey privateKey = tryDecryptOrRebootstrap(entityWithMetadata, signingKey, aesKey);
+            subjectTokenSigner.setActiveKey(privateKey);
+            logger.info("OBO signing key loaded from Cyoda entity (key ID: {})", signingKey.getKeyId());
+
+            checkCyodaKeyValidity(entityWithMetadata, signingKey, aesKey);
+
+        } catch (OboTokenException e) {
+            logger.error("OBO key setup failed: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error during OBO key setup: {}", e.getMessage(), e);
+        } finally {
+            SecurityContextHolder.setContext(previous);
+        }
+    }
+
+    /**
+     * Attempts to decrypt the stored private key. If decryption fails (e.g. the
+     * encryption key changed due to a new Docker image build or secret rotation),
+     * re-bootstraps with a new RSA key pair encrypted under the current key.
+     */
+    private RSAPrivateKey tryDecryptOrRebootstrap(EntityWithMetadata<OboSigningKey> entityWithMetadata,
+                                                   OboSigningKey signingKey, SecretKey aesKey) {
+        try {
+            return decryptPrivateKey(signingKey.getEncryptedPrivateKey(), aesKey);
+        } catch (OboTokenException e) {
+            logger.warn("Failed to decrypt existing OBO signing key — encryption key has likely changed "
+                    + "(new image build or secret rotation). Re-bootstrapping RSA key pair with grace period.");
+            return rebootstrapKey(entityWithMetadata, aesKey);
+        }
+    }
+
+    private RSAPrivateKey rebootstrapKey(EntityWithMetadata<OboSigningKey> entityWithMetadata, SecretKey aesKey) {
+        KeyPair keyPair = generateRsaKeyPair();
+        RSAPrivateKey newPrivateKey = (RSAPrivateKey) keyPair.getPrivate();
+        RSAPublicKey newPublicKey = (RSAPublicKey) keyPair.getPublic();
+
+        String newPublicKeyDer = Base64.getEncoder().encodeToString(newPublicKey.getEncoded());
+        int graceSec = oboProperties.getRotationGracePeriodSeconds();
+        String newExpiresAt = registerPublicKeyWithCyoda(newPublicKey, true, graceSec);
+
+        String encryptedNewPrivateKey = AesGcmEncryption.encrypt(newPrivateKey.getEncoded(), aesKey);
+
+        OboSigningKey updated = entityWithMetadata.entity();
+        updated.setEncryptedPrivateKey(encryptedNewPrivateKey);
+        updated.setPublicKeyDer(newPublicKeyDer);
+        updated.setCyodaKeyExpiresAt(newExpiresAt);
+        updated.setLastRotatedAt(Instant.now().toString());
+
+        entityService.update(entityWithMetadata.metadata().getId(), updated, null);
+        logger.info("OBO signing key re-bootstrapped after encryption key change (grace period: {}s)", graceSec);
+
+        return newPrivateKey;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String fetchCaasOrgId() {
+        String bearerToken = authentication.getAccessToken().getTokenValue();
+        Map<String, Object> response = restClient.get()
+                .uri(config.getCyodaApiUrl() + "/account")
+                .header("Authorization", "Bearer " + bearerToken)
+                .retrieve()
+                .body(Map.class);
+        try {
+            if (response == null) {
+                throw new OboTokenException("Cyoda /account returned null response");
+            }
+            Map<String, Object> userAccountInfo = (Map<String, Object>) response.get("userAccountInfo");
+            Map<String, Object> legalEntity = (Map<String, Object>) userAccountInfo.get("legalEntity");
+            String orgId = (String) legalEntity.get("id");
+            if (orgId == null || orgId.isBlank()) {
+                throw new OboTokenException("Cyoda /account returned a blank legalEntity.id");
+            }
+            return orgId;
+        } catch (OboTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to extract caas_org_id from Cyoda /account response", e);
+        }
+    }
+
+    private void ensureEntityModelRegistered() {
+        String bearerToken = authentication.getAccessToken().getTokenValue();
+        String entityName = OboSigningKey.ENTITY_NAME;
+        int version = OboSigningKey.ENTITY_VERSION;
+
+        boolean exists = checkEntityModelExists(bearerToken, entityName, version);
+        if (exists) {
+            logger.debug("OboSigningKey entity model already exists in Cyoda");
+            return;
+        }
+
+        logger.info("OboSigningKey entity model not found in Cyoda — bootstrapping");
+
+        String workflowJson = loadWorkflowJsonFromClasspath();
+        String workflowBody = "{\"workflows\":" + workflowJson + ",\"importMode\":\"REPLACE\"}";
+        restClient.post()
+                .uri(config.getCyodaApiUrl() + "/model/{name}/{version}/workflow/import",
+                        entityName, version)
+                .header("Authorization", "Bearer " + bearerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(workflowBody)
+                .retrieve()
+                .toBodilessEntity();
+        logger.info("OboSigningKey workflow imported");
+
+        String sampleJson = loadSampleEntityJsonFromClasspath();
+        restClient.post()
+                .uri(config.getCyodaApiUrl() + "/model/import/JSON/SAMPLE_DATA/{name}/{version}",
+                        entityName, version)
+                .header("Authorization", "Bearer " + bearerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(sampleJson)
+                .retrieve()
+                .toBodilessEntity();
+        logger.info("OboSigningKey entity model schema created");
+
+        restClient.post()
+                .uri(config.getCyodaApiUrl() + "/model/{name}/{version}/changeLevel/STRUCTURAL",
+                        entityName, version)
+                .header("Authorization", "Bearer " + bearerToken)
+                .retrieve()
+                .toBodilessEntity();
+
+        restClient.put()
+                .uri(config.getCyodaApiUrl() + "/model/{name}/{version}/lock",
+                        entityName, version)
+                .header("Authorization", "Bearer " + bearerToken)
+                .retrieve()
+                .toBodilessEntity();
+
+        logger.info("OboSigningKey entity model registered and locked in Cyoda");
+    }
+
+    private boolean checkEntityModelExists(String bearerToken, String entityName, int version) {
+        try {
+            restClient.get()
+                    .uri(config.getCyodaApiUrl() + "/model/export/SIMPLE_VIEW/{name}/{version}",
+                            entityName, version)
+                    .header("Authorization", "Bearer " + bearerToken)
+                    .retrieve()
+                    .toBodilessEntity();
+            return true;
+        } catch (org.springframework.web.client.HttpClientErrorException.NotFound e) {
+            return false;
+        }
+    }
+
+    private String loadWorkflowJsonFromClasspath() {
+        String path = "/workflow/v1/obosigningkey.json";
+        try (var stream = getClass().getResourceAsStream(path)) {
+            if (stream == null) {
+                throw new OboTokenException("OboSigningKey workflow file not found on classpath: " + path);
+            }
+            return new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (OboTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to load OboSigningKey workflow JSON from classpath", e);
+        }
+    }
+
+    private String loadSampleEntityJsonFromClasspath() {
+        String path = "/entity-schemas/examples/OboSigningKey/obo-signing-key.json";
+        try (var stream = getClass().getResourceAsStream(path)) {
+            if (stream == null) {
+                logger.warn("OboSigningKey sample JSON not found at {}; using inline fallback", path);
+                return "{\"key_id\":\"example\",\"encrypted_private_key\":\"ZQ==\","
+                        + "\"public_key_der\":\"ZQ==\","
+                        + "\"cyoda_key_expires_at\":\"2027-01-01T00:00:00Z\","
+                        + "\"last_rotated_at\":\"2026-01-01T00:00:00Z\"}";
+            }
+            return new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to load OboSigningKey sample entity JSON", e);
+        }
+    }
+
+    private void bootstrapNewKey(SecretKey aesKey) {
+        KeyPair keyPair = generateRsaKeyPair();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+
+        String encryptedPrivateKey = AesGcmEncryption.encrypt(privateKey.getEncoded(), aesKey);
+        String publicKeyDer = Base64.getEncoder().encodeToString(publicKey.getEncoded());
+        String expiresAt = registerPublicKeyWithCyoda(publicKey, false, 0);
+
+        OboSigningKey entity = new OboSigningKey();
+        entity.setKeyId(oboProperties.getKeyId());
+        entity.setEncryptedPrivateKey(encryptedPrivateKey);
+        entity.setPublicKeyDer(publicKeyDer);
+        entity.setCyodaKeyExpiresAt(expiresAt);
+        entity.setLastRotatedAt(Instant.now().toString());
+
+        entityService.create(entity);
+        subjectTokenSigner.setActiveKey(privateKey);
+        logger.info("OBO key bootstrapped and registered with Cyoda (key ID: {}, expires: {})",
+                oboProperties.getKeyId(), expiresAt);
+    }
+
+    private void checkCyodaKeyValidity(EntityWithMetadata<OboSigningKey> entityWithMetadata,
+                                        OboSigningKey signingKey, SecretKey aesKey) {
+        String cyodaKeyExpiresAt = signingKey.getCyodaKeyExpiresAt();
+        if (cyodaKeyExpiresAt == null) {
+            logger.warn("OboSigningKey entity has no cyodaKeyExpiresAt — treating as expired; rotating");
+            rotateKey(entityWithMetadata, aesKey, false);
+            return;
+        }
+
+        LocalDate expiryDate;
+        try {
+            expiryDate = Instant.parse(cyodaKeyExpiresAt)
+                    .atZone(ZoneOffset.UTC).toLocalDate();
+        } catch (Exception e) {
+            expiryDate = LocalDate.parse(cyodaKeyExpiresAt, DateTimeFormatter.ISO_LOCAL_DATE);
+        }
+
+        long daysRemaining = LocalDate.now(ZoneOffset.UTC).until(expiryDate).getDays();
+
+        if (daysRemaining <= 0) {
+            logger.warn("OBO signing key has expired ({}) — rotating immediately", cyodaKeyExpiresAt);
+            rotateKey(entityWithMetadata, aesKey, false);
+        } else if (daysRemaining <= oboProperties.getRotationWarningDays()) {
+            logger.warn("OBO signing key expires in {} day(s) — auto-rotating with grace period", daysRemaining);
+            rotateKey(entityWithMetadata, aesKey, true);
+        } else {
+            logger.debug("OBO signing key is healthy; expires in {} day(s)", daysRemaining);
+        }
+    }
+
+    private void rotateKey(EntityWithMetadata<OboSigningKey> entityWithMetadata,
+                           SecretKey aesKey, boolean withGracePeriod) {
+        try {
+            KeyPair keyPair = generateRsaKeyPair();
+            RSAPrivateKey newPrivateKey = (RSAPrivateKey) keyPair.getPrivate();
+            RSAPublicKey newPublicKey = (RSAPublicKey) keyPair.getPublic();
+
+            String newPublicKeyDer = Base64.getEncoder().encodeToString(newPublicKey.getEncoded());
+            int graceSec = withGracePeriod ? oboProperties.getRotationGracePeriodSeconds() : 0;
+            String newExpiresAt = registerPublicKeyWithCyoda(newPublicKey, true, graceSec);
+
+            String encryptedNewPrivateKey = AesGcmEncryption.encrypt(newPrivateKey.getEncoded(), aesKey);
+
+            OboSigningKey updated = entityWithMetadata.entity();
+            updated.setEncryptedPrivateKey(encryptedNewPrivateKey);
+            updated.setPublicKeyDer(newPublicKeyDer);
+            updated.setCyodaKeyExpiresAt(newExpiresAt);
+            updated.setLastRotatedAt(Instant.now().toString());
+
+            entityService.update(entityWithMetadata.metadata().getId(), updated, null);
+            subjectTokenSigner.setActiveKey(newPrivateKey);
+
+            logger.info("OBO signing key rotated successfully (new expiry: {}, grace period: {}s)",
+                    newExpiresAt, graceSec);
+
+        } catch (Exception e) {
+            logger.error("OBO key rotation failed: {}", e.getMessage(), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String fetchAdminToken() {
+        String credentials = Base64.getEncoder().encodeToString(
+                (oboProperties.getAdminClientId() + ":" + oboProperties.getAdminClientSecret())
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        Map<String, Object> response = restClient.post()
+                .uri(config.getCyodaApiUrl() + "/oauth/token")
+                .header("Authorization", "Basic " + credentials)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body("grant_type=client_credentials")
+                .retrieve()
+                .body(Map.class);
+        if (response == null || response.get("access_token") == null) {
+            throw new OboTokenException("Admin token exchange returned no access_token");
+        }
+        return (String) response.get("access_token");
+    }
+
+    @SuppressWarnings("unchecked")
+    private String registerPublicKeyWithCyoda(RSAPublicKey publicKey,
+                                               boolean invalidatePrevious, int gracePeriodSeconds) {
+        String bearerToken = fetchAdminToken();
+
+        RSAKey jwk = new RSAKey.Builder(publicKey)
+                .keyID(oboProperties.getKeyId())
+                .algorithm(new Algorithm("RS256"))
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
+
+        String validTo = Instant.now()
+                .plus(Duration.ofDays(oboProperties.getValidityDays()))
+                .atZone(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("keyId", oboProperties.getKeyId());
+        body.put("jwk", jwk.toJSONObject());
+        body.put("audience", "human");
+        body.put("issuers", List.of(oboProperties.getIssuer()));
+        body.put("validTo", validTo);
+        if (invalidatePrevious) {
+            body.put("invalidatePrevious", true);
+            body.put("invalidateGracePeriodSec", gracePeriodSeconds);
+        }
+
+        try {
+            Map<String, Object> response = restClient.post()
+                    .uri(config.getCyodaApiUrl() + "/oauth/keys/trusted")
+                    .header("Authorization", "Bearer " + bearerToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+
+            String responseValidTo = response != null ? (String) response.get("validTo") : null;
+            if (responseValidTo == null) {
+                responseValidTo = validTo;
+            }
+            return responseValidTo;
+
+        } catch (HttpClientErrorException.Conflict e) {
+            throw new OboTokenException(
+                    "Trusted key '" + oboProperties.getKeyId() + "' is owned by a different tenant in Cyoda. "
+                    + "Each tenant must use a unique keyId. Check app.obo.key-id configuration. "
+                    + "Detail: " + e.getResponseBodyAsString());
+        }
+    }
+
+    private RSAPrivateKey decryptPrivateKey(String encryptedPrivateKey, SecretKey aesKey) {
+        try {
+            byte[] pkcs8Bytes = AesGcmEncryption.decrypt(encryptedPrivateKey, aesKey);
+            return (RSAPrivateKey) java.security.KeyFactory.getInstance("RSA")
+                    .generatePrivate(new java.security.spec.PKCS8EncodedKeySpec(pkcs8Bytes));
+        } catch (OboTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to decrypt OBO private key from entity", e);
+        }
+    }
+
+    private static KeyPair generateRsaKeyPair() {
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(2048);
+            return kpg.generateKeyPair();
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to generate RSA key pair", e);
+        }
+    }
+}

--- a/src/main/java/com/java_template/common/auth/OboProperties.java
+++ b/src/main/java/com/java_template/common/auth/OboProperties.java
@@ -1,0 +1,97 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Configuration properties for Cyoda OBO (On-Behalf-Of) token exchange.
+// The encryption key can be supplied via the encryption-key property (env var) or read
+// from a file at the path given by encryption-key-file. The env var takes precedence.
+// When neither source provides a key, isEnabled() returns false and any user-triggered
+// Cyoda call will throw OboTokenException (fail-fast).
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@ConfigurationProperties(prefix = OboProperties.CONFIG_PREFIX)
+public class OboProperties {
+
+    private static final Logger logger = LoggerFactory.getLogger(OboProperties.class);
+
+    public static final String CONFIG_PREFIX = "app.obo";
+
+    private String encryptionKey = "";
+    private String encryptionKeyFile = "/app/obo-encryption-key.txt";
+    private String adminClientId = "";
+    private String adminClientSecret = "";
+    private String keyId = "bloc-portal-key-001";
+    private String issuer = "bloc-portal-local";
+    private int subjectTokenTtlSeconds = 300;
+    private String rolesClaimName = "roles";
+    private int validityDays = 90;
+    private int rotationWarningDays = 14;
+    private int rotationGracePeriodSeconds = 3600;
+
+    /**
+     * Resolves the encryption key from the env-var property first, falling back to the
+     * file path. Returns null if neither source provides a key.
+     */
+    public String resolveEncryptionKey() {
+        if (encryptionKey != null && !encryptionKey.isBlank()) {
+            return encryptionKey;
+        }
+        if (encryptionKeyFile != null && !encryptionKeyFile.isBlank()) {
+            Path path = Path.of(encryptionKeyFile);
+            if (Files.isReadable(path)) {
+                try {
+                    String key = Files.readString(path).trim();
+                    if (!key.isBlank()) {
+                        logger.info("OBO encryption key loaded from file: {}", encryptionKeyFile);
+                        return key;
+                    }
+                } catch (IOException e) {
+                    logger.warn("Failed to read OBO encryption key file {}: {}", encryptionKeyFile, e.getMessage());
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean isEnabled() {
+        return resolveEncryptionKey() != null;
+    }
+
+    public String getEncryptionKey() { return encryptionKey; }
+    public void setEncryptionKey(String encryptionKey) { this.encryptionKey = encryptionKey; }
+
+    public String getEncryptionKeyFile() { return encryptionKeyFile; }
+    public void setEncryptionKeyFile(String encryptionKeyFile) { this.encryptionKeyFile = encryptionKeyFile; }
+
+    public String getAdminClientId() { return adminClientId; }
+    public void setAdminClientId(String adminClientId) { this.adminClientId = adminClientId; }
+
+    public String getAdminClientSecret() { return adminClientSecret; }
+    public void setAdminClientSecret(String adminClientSecret) { this.adminClientSecret = adminClientSecret; }
+
+    public String getKeyId() { return keyId; }
+    public void setKeyId(String keyId) { this.keyId = keyId; }
+
+    public String getIssuer() { return issuer; }
+    public void setIssuer(String issuer) { this.issuer = issuer; }
+
+    public int getSubjectTokenTtlSeconds() { return subjectTokenTtlSeconds; }
+    public void setSubjectTokenTtlSeconds(int s) { this.subjectTokenTtlSeconds = s; }
+
+    public String getRolesClaimName() { return rolesClaimName; }
+    public void setRolesClaimName(String rolesClaimName) { this.rolesClaimName = rolesClaimName; }
+
+    public int getValidityDays() { return validityDays; }
+    public void setValidityDays(int validityDays) { this.validityDays = validityDays; }
+
+    public int getRotationWarningDays() { return rotationWarningDays; }
+    public void setRotationWarningDays(int rotationWarningDays) { this.rotationWarningDays = rotationWarningDays; }
+
+    public int getRotationGracePeriodSeconds() { return rotationGracePeriodSeconds; }
+    public void setRotationGracePeriodSeconds(int s) { this.rotationGracePeriodSeconds = s; }
+}

--- a/src/main/java/com/java_template/common/auth/OboSigningKey.java
+++ b/src/main/java/com/java_template/common/auth/OboSigningKey.java
@@ -1,0 +1,61 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Cyoda entity holding the OBO signing key state, including the AES-encrypted RSA private key.
+// Only one instance per deployment; managed entirely by OboKeyRegistrationService.
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.java_template.common.workflow.CyodaEntity;
+import com.java_template.common.workflow.OperationSpecification;
+import org.cyoda.cloud.api.event.common.EntityMetadata;
+import org.cyoda.cloud.api.event.common.ModelSpec;
+
+public class OboSigningKey implements CyodaEntity {
+
+    public static final String ENTITY_NAME = "OboSigningKey";
+    public static final Integer ENTITY_VERSION = 1;
+    public static final ModelSpec MODEL_SPEC = new ModelSpec()
+            .withName(ENTITY_NAME)
+            .withVersion(ENTITY_VERSION);
+
+    @JsonProperty("key_id")
+    private String keyId;
+
+    @JsonProperty("encrypted_private_key")
+    private String encryptedPrivateKey;
+
+    @JsonProperty("public_key_der")
+    private String publicKeyDer;
+
+    @JsonProperty("cyoda_key_expires_at")
+    private String cyodaKeyExpiresAt;
+
+    @JsonProperty("last_rotated_at")
+    private String lastRotatedAt;
+
+    @Override
+    public OperationSpecification getModelKey() {
+        return new OperationSpecification.Entity(MODEL_SPEC, ENTITY_NAME);
+    }
+
+    @Override
+    public boolean isValid(EntityMetadata metadata) {
+        return keyId != null && !keyId.isBlank()
+                && encryptedPrivateKey != null && !encryptedPrivateKey.isBlank()
+                && publicKeyDer != null && !publicKeyDer.isBlank();
+    }
+
+    public String getKeyId() { return keyId; }
+    public void setKeyId(String keyId) { this.keyId = keyId; }
+
+    public String getEncryptedPrivateKey() { return encryptedPrivateKey; }
+    public void setEncryptedPrivateKey(String encryptedPrivateKey) { this.encryptedPrivateKey = encryptedPrivateKey; }
+
+    public String getPublicKeyDer() { return publicKeyDer; }
+    public void setPublicKeyDer(String publicKeyDer) { this.publicKeyDer = publicKeyDer; }
+
+    public String getCyodaKeyExpiresAt() { return cyodaKeyExpiresAt; }
+    public void setCyodaKeyExpiresAt(String cyodaKeyExpiresAt) { this.cyodaKeyExpiresAt = cyodaKeyExpiresAt; }
+
+    public String getLastRotatedAt() { return lastRotatedAt; }
+    public void setLastRotatedAt(String lastRotatedAt) { this.lastRotatedAt = lastRotatedAt; }
+}

--- a/src/main/java/com/java_template/common/auth/OboTokenException.java
+++ b/src/main/java/com/java_template/common/auth/OboTokenException.java
@@ -1,0 +1,15 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Thrown when OBO token exchange fails for a user-triggered action.
+// Signals that a Cyoda call cannot be attributed to the correct user identity.
+
+public class OboTokenException extends RuntimeException {
+
+    public OboTokenException(String message) {
+        super(message);
+    }
+
+    public OboTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/java_template/common/auth/OboTokenService.java
+++ b/src/main/java/com/java_template/common/auth/OboTokenService.java
@@ -1,0 +1,160 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Exchanges locally-signed subject tokens for Cyoda OBO access tokens (RFC 8693).
+// Caches OBO tokens per user UUID in a Caffeine cache with per-entry expiry;
+// entries expire 60 seconds before the token's stated expiry to avoid clock-skew races.
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.java_template.common.config.Config;
+import com.java_template.common.util.SslUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class OboTokenService {
+
+    private static final Logger logger = LoggerFactory.getLogger(OboTokenService.class);
+
+    private static final String GRANT_TYPE =
+            "urn:ietf:params:oauth:grant-type:token-exchange";
+    private static final String SUBJECT_TOKEN_TYPE =
+            "urn:ietf:params:oauth:token-type:jwt";
+    private static final long EXPIRY_BUFFER_SECONDS = 60;
+    private static final long FALLBACK_TTL_SECONDS = 3600;
+
+    private final OboProperties oboProperties;
+    private final SubjectTokenSigner subjectTokenSigner;
+    private final Config config;
+    private final RestClient restClient;
+
+    private final Cache<String, OAuth2AccessToken> tokenCache = Caffeine.newBuilder()
+            .expireAfter(new Expiry<String, OAuth2AccessToken>() {
+
+                @Override
+                public long expireAfterCreate(String key, OAuth2AccessToken token, long currentTime) {
+                    return ttlNanos(token);
+                }
+
+                @Override
+                public long expireAfterUpdate(String key, OAuth2AccessToken token,
+                                              long currentTime, long currentDuration) {
+                    return ttlNanos(token);
+                }
+
+                @Override
+                public long expireAfterRead(String key, OAuth2AccessToken token,
+                                            long currentTime, long currentDuration) {
+                    return currentDuration;
+                }
+
+                private long ttlNanos(OAuth2AccessToken token) {
+                    Instant expiresAt = token.getExpiresAt();
+                    if (expiresAt == null) {
+                        return TimeUnit.SECONDS.toNanos(FALLBACK_TTL_SECONDS);
+                    }
+                    long nanos = Duration.between(Instant.now(), expiresAt)
+                            .minusSeconds(EXPIRY_BUFFER_SECONDS)
+                            .toNanos();
+                    return Math.max(0, nanos);
+                }
+            })
+            .build();
+
+    public OboTokenService(OboProperties oboProperties, SubjectTokenSigner subjectTokenSigner, Config config) {
+        this.oboProperties = oboProperties;
+        this.subjectTokenSigner = subjectTokenSigner;
+        this.config = config;
+        this.restClient = RestClient.builder()
+                .requestFactory(new JdkClientHttpRequestFactory(SslUtils.createHttpClient(config)))
+                .build();
+    }
+
+    public Optional<OAuth2AccessToken> getOboToken(String userId, List<String> userRoles) {
+        if (!oboProperties.isEnabled()) {
+            return Optional.empty();
+        }
+        OAuth2AccessToken token = tokenCache.get(userId, k -> exchange(userId, userRoles));
+        return Optional.ofNullable(token);
+    }
+
+    public void invalidate(String userId) {
+        tokenCache.invalidate(userId);
+        logger.debug("Evicted OBO token cache for user {}", userId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OAuth2AccessToken exchange(String userId, List<String> userRoles) {
+        try {
+            String subjectToken = subjectTokenSigner.sign(userId, userRoles);
+            String credentials = Base64.getEncoder().encodeToString(
+                    (config.getCyodaClientId() + ":" + config.getCyodaClientSecret()).getBytes()
+            );
+            String body = "grant_type=" + GRANT_TYPE
+                    + "&subject_token=" + subjectToken
+                    + "&subject_token_type=" + SUBJECT_TOKEN_TYPE;
+
+            Map<String, Object> response = restClient.post()
+                    .uri(config.getCyodaApiUrl() + "/oauth/token")
+                    .header("Authorization", "Basic " + credentials)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response == null || !response.containsKey("access_token")) {
+                logger.warn("OBO exchange for user {} returned no access_token", userId);
+                return null;
+            }
+
+            String tokenValue = (String) response.get("access_token");
+            Number expiresIn = (Number) response.get("expires_in");
+            String issuedTokenType = (String) response.get("issued_token_type");
+            if (issuedTokenType != null) {
+                logger.debug("OBO exchange issued_token_type: {}", issuedTokenType);
+            }
+            Instant expiresAt = expiresIn != null
+                    ? Instant.now().plusSeconds(expiresIn.longValue())
+                    : Instant.now().plusSeconds(FALLBACK_TTL_SECONDS);
+
+            logger.debug("OBO token obtained for user {}, expires at {}", userId, expiresAt);
+            return new OAuth2AccessToken(
+                    OAuth2AccessToken.TokenType.BEARER, tokenValue, Instant.now(), expiresAt);
+
+        } catch (OboTokenException e) {
+            throw e;
+        } catch (HttpClientErrorException.Forbidden e) {
+            String detail = e.getResponseBodyAsString();
+            throw new OboTokenException(
+                    "OBO token exchange rejected: tenant boundary violation for user " + userId
+                    + ". The M2M client and user belong to different tenants. "
+                    + "Check APP_CONFIG_CYODA_CLIENT_ID configuration. Detail: " + detail);
+        } catch (HttpClientErrorException.Unauthorized e) {
+            String detail = e.getResponseBodyAsString();
+            logger.error("OBO subject token rejected by Cyoda for user {} — "
+                    + "the signing key may have expired or been invalidated. Detail: {}",
+                    userId, detail);
+            throw new OboTokenException(
+                    "OBO subject token validation failed for user " + userId
+                    + ". The signing key may need rotation. Detail: " + detail);
+        } catch (Exception e) {
+            logger.error("OBO token exchange failed for user {}: {}", userId, e.getMessage(), e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/java_template/common/auth/SubjectTokenSigner.java
+++ b/src/main/java/com/java_template/common/auth/SubjectTokenSigner.java
@@ -1,0 +1,87 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Signs RS256 subject tokens for Cyoda OBO token exchange (RFC 8693).
+// Receives pre-processed role strings (no "ROLE_" prefix) and places them in the user_roles claim.
+// The signing key is injected by OboKeyRegistrationService after decryption from the OboSigningKey entity.
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class SubjectTokenSigner {
+
+    private static final Logger logger = LoggerFactory.getLogger(SubjectTokenSigner.class);
+
+    private final OboProperties oboProperties;
+
+    private volatile RSAPrivateKey activeKey;
+    private volatile String activeCaasOrgId;
+
+    public SubjectTokenSigner(OboProperties oboProperties) {
+        this.oboProperties = oboProperties;
+    }
+
+    public String sign(String userId, List<String> userRoles) {
+        RSAPrivateKey key = activeKey;
+        String orgId = activeCaasOrgId;
+        if (key == null) {
+            throw new OboTokenException(
+                    "OBO signing key is not yet available. OboKeyRegistrationService may have " +
+                    "failed to load the key from Cyoda at startup. Check logs for details.");
+        }
+        if (orgId == null) {
+            throw new OboTokenException(
+                    "caas_org_id is not yet available. OboKeyRegistrationService may have " +
+                    "failed to fetch it from the Cyoda /account endpoint at startup. Check logs.");
+        }
+        try {
+            JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                    .keyID(oboProperties.getKeyId())
+                    .build();
+
+            Instant now = Instant.now();
+            JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                    .issuer(oboProperties.getIssuer())
+                    .subject(userId)
+                    .issueTime(Date.from(now))
+                    .expirationTime(Date.from(now.plusSeconds(oboProperties.getSubjectTokenTtlSeconds())))
+                    .claim("caas_org_id", orgId)
+                    .claim("user_roles", userRoles)
+                    .build();
+
+            SignedJWT jwt = new SignedJWT(header, claims);
+            jwt.sign(new RSASSASigner(key));
+            return jwt.serialize();
+
+        } catch (OboTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OboTokenException("Failed to sign OBO subject token for user: " + userId, e);
+        }
+    }
+
+    public void setActiveKey(RSAPrivateKey key) {
+        this.activeKey = key;
+        logger.info("OBO signing key activated (key ID: {})", oboProperties.getKeyId());
+    }
+
+    public void setActiveCaasOrgId(String caasOrgId) {
+        this.activeCaasOrgId = caasOrgId;
+        logger.info("OBO caas_org_id set ({})", caasOrgId);
+    }
+
+    public boolean isKeyLoaded() {
+        return activeKey != null;
+    }
+}

--- a/src/main/java/com/java_template/common/config/Config.java
+++ b/src/main/java/com/java_template/common/config/Config.java
@@ -56,6 +56,13 @@ public class Config {
 
     private boolean includeDefaultOperations = false;
 
+    private boolean skipSsl = false;
+    private String executionMode = "platform";
+    private CyodaLight cyodaLight = new CyodaLight();
+
+    /** Base package scanned for {@link com.java_template.common.workflow.CyodaEntity} implementations. */
+    private String entityBasePackage = "com.java_template.application";
+
     // Getters and setters
 
     public String getCyodaHost() {
@@ -293,6 +300,38 @@ public class Config {
         this.includeDefaultOperations = includeDefaultOperations;
     }
 
+    public boolean isSkipSsl() {
+        return skipSsl;
+    }
+
+    public void setSkipSsl(boolean skipSsl) {
+        this.skipSsl = skipSsl;
+    }
+
+    public String getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(String executionMode) {
+        this.executionMode = executionMode;
+    }
+
+    public CyodaLight getCyodaLight() {
+        return cyodaLight;
+    }
+
+    public void setCyodaLight(CyodaLight cyodaLight) {
+        this.cyodaLight = cyodaLight;
+    }
+
+    public String getEntityBasePackage() {
+        return entityBasePackage;
+    }
+
+    public void setEntityBasePackage(String entityBasePackage) {
+        this.entityBasePackage = entityBasePackage;
+    }
+
     /**
      * Get list of hosts that should be trusted even with self-signed certificates
      * @return List of trusted hosts
@@ -305,5 +344,49 @@ public class Config {
                 .map(String::trim)
                 .filter(host -> !host.isEmpty())
                 .toList();
+    }
+
+    /**
+     * Configuration for the cyoda-light in-memory digital twin sidecar.
+     * When active, {@link CyodaLightConfigCustomizer} injects property overrides
+     * into the Spring Environment so Config binds directly to the sidecar's endpoints.
+     */
+    public static class CyodaLight {
+        private boolean active = false;
+        private String httpUrl = "http://cyoda-light:8080";
+        private String grpcHost = "cyoda-light";
+        private int grpcPort = 50051;
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+
+        public String getHttpUrl() {
+            return httpUrl;
+        }
+
+        public void setHttpUrl(String httpUrl) {
+            this.httpUrl = httpUrl;
+        }
+
+        public String getGrpcHost() {
+            return grpcHost;
+        }
+
+        public void setGrpcHost(String grpcHost) {
+            this.grpcHost = grpcHost;
+        }
+
+        public int getGrpcPort() {
+            return grpcPort;
+        }
+
+        public void setGrpcPort(int grpcPort) {
+            this.grpcPort = grpcPort;
+        }
     }
 }

--- a/src/main/java/com/java_template/common/config/CyodaLightConfigCustomizer.java
+++ b/src/main/java/com/java_template/common/config/CyodaLightConfigCustomizer.java
@@ -1,0 +1,73 @@
+package com.java_template.common.config;
+
+// ABOUTME: Redirects platform communication at the cyoda-light in-memory digital twin by
+// injecting property overrides into the Spring Environment before @ConfigurationProperties
+// binding runs, so Config is bound directly to the sidecar's endpoints with no post-hoc mutation.
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Spring Boot {@link EnvironmentPostProcessor} that rewrites the platform connection
+ * properties to target the cyoda-light in-memory digital twin when the feature toggle
+ * {@code app.config.cyoda-light.active=true} is set.
+ *
+ * <p>Running as an {@code EnvironmentPostProcessor} — registered in
+ * {@code META-INF/spring.factories} — ensures the overrides are applied <em>before</em>
+ * any {@code @ConfigurationProperties} bean is bound. {@link Config} therefore sees the
+ * cyoda-light endpoints directly; no bean mutation or ordering dependency is required.
+ *
+ * <p>The overrides are installed as a high-priority {@link MapPropertySource} so they win
+ * over application.yml defaults while still being overridable by an explicit environment
+ * variable (env vars sit in {@code systemEnvironment} which has higher precedence).
+ */
+public class CyodaLightConfigCustomizer implements EnvironmentPostProcessor, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(CyodaLightConfigCustomizer.class);
+
+    private static final String ACTIVE_PROPERTY = "app.config.cyoda-light.active";
+    private static final String PROPERTY_SOURCE_NAME = "cyodaLightOverrides";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        Boolean active = environment.getProperty(ACTIVE_PROPERTY, Boolean.class, Boolean.FALSE);
+        if (!Boolean.TRUE.equals(active)) {
+            return;
+        }
+
+        String httpUrl = environment.getProperty(
+                "app.config.cyoda-light.http-url", "http://cyoda-light:8080");
+        String grpcHost = environment.getProperty(
+                "app.config.cyoda-light.grpc-host", "cyoda-light");
+        int grpcPort = environment.getProperty(
+                "app.config.cyoda-light.grpc-port", Integer.class, 50051);
+
+        Map<String, Object> overrides = new LinkedHashMap<>();
+        overrides.put("app.config.cyoda-api-url", httpUrl + "/api");
+        overrides.put("app.config.grpc-address", grpcHost);
+        overrides.put("app.config.grpc-server-port", grpcPort);
+        overrides.put("app.config.skip-ssl", true);
+        overrides.put("app.config.ssl-trust-all", true);
+
+        // addFirst ensures these overrides take precedence over application.yml, but
+        // systemEnvironment / command-line args (which sit in earlier sources) still win.
+        environment.getPropertySources().addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, overrides));
+
+        log.info("cyoda-light active — targeting HTTP={}, gRPC={}:{}", httpUrl, grpcHost, grpcPort);
+    }
+
+    @Override
+    public int getOrder() {
+        // Run after Spring Boot's ConfigDataEnvironmentPostProcessor so application.yml
+        // is already on the environment and we can read the toggle from it.
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/src/main/java/com/java_template/common/config/GrpcClientAutoConfiguration.java
+++ b/src/main/java/com/java_template/common/config/GrpcClientAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.java_template.common.config;
 
 import com.java_template.common.auth.Authentication;
 import com.java_template.common.grpc.client.ClientAuthorizationInterceptor;
+import com.java_template.common.observability.GrpcObservabilityInterceptor;
 import com.java_template.common.grpc.client.CalculationExecutionStrategy;
 import com.java_template.common.grpc.client.ControlThreadExecutor;
 import com.java_template.common.grpc.client.CriteriaThreadExecutor;
@@ -23,11 +24,11 @@ import java.util.function.Supplier;
 import org.cyoda.cloud.api.grpc.CloudEventsServiceGrpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.lang.Nullable;
 
 
 /**
@@ -49,13 +50,12 @@ public class GrpcClientAutoConfiguration {
 
     @Bean
     public ManagedChannel managedChannel(
-            final ConnectionStateTracker connectionStateTracker,
-            @Value("${connection.grpc.skip-ssl:false}") final boolean grpcSkipSsl
+            final ConnectionStateTracker connectionStateTracker
     ) {
         final ManagedChannel channel = SslUtils.createGrpcChannelBuilder(
                 config.getGrpcAddress(),
                 config.getGrpcServerPort(),
-                grpcSkipSsl,
+                config.isSkipSsl(),
                 config
         ).build();
 
@@ -73,34 +73,49 @@ public class GrpcClientAutoConfiguration {
     @Bean
     public CloudEventsServiceGrpc.CloudEventsServiceStub cloudEventsServiceStub(
             final Authentication authentication,
-            final ManagedChannel managedChannel
+            final ManagedChannel managedChannel,
+            @Nullable final GrpcObservabilityInterceptor observabilityInterceptor
     ) {
         final var authInterceptor = new ClientAuthorizationInterceptor(authentication);
-        return CloudEventsServiceGrpc.newStub(managedChannel)
+        var stub = CloudEventsServiceGrpc.newStub(managedChannel)
                 .withWaitForReady()
                 .withInterceptors(authInterceptor);
+        if (observabilityInterceptor != null) {
+            stub = stub.withInterceptors(observabilityInterceptor);
+        }
+        return stub;
     }
 
     @Bean
     public CloudEventsServiceGrpc.CloudEventsServiceBlockingStub cloudEventsServiceBlockingStub(
             final Authentication authentication,
-            final ManagedChannel managedChannel
+            final ManagedChannel managedChannel,
+            @Nullable final GrpcObservabilityInterceptor observabilityInterceptor
     ) {
         final var authInterceptor = new ClientAuthorizationInterceptor(authentication);
-        return CloudEventsServiceGrpc.newBlockingStub(managedChannel)
+        var stub = CloudEventsServiceGrpc.newBlockingStub(managedChannel)
                 .withWaitForReady()
                 .withInterceptors(authInterceptor);
+        if (observabilityInterceptor != null) {
+            stub = stub.withInterceptors(observabilityInterceptor);
+        }
+        return stub;
     }
 
     @Bean
     public CloudEventsServiceGrpc.CloudEventsServiceFutureStub cloudEventsServiceFutureStub(
             final Authentication authentication,
-            final ManagedChannel managedChannel
+            final ManagedChannel managedChannel,
+            @Nullable final GrpcObservabilityInterceptor observabilityInterceptor
     ) {
         final var authInterceptor = new ClientAuthorizationInterceptor(authentication);
-        return CloudEventsServiceGrpc.newFutureStub(managedChannel)
+        var stub = CloudEventsServiceGrpc.newFutureStub(managedChannel)
                 .withWaitForReady()
                 .withInterceptors(authInterceptor);
+        if (observabilityInterceptor != null) {
+            stub = stub.withInterceptors(observabilityInterceptor);
+        }
+        return stub;
     }
 
     @Bean
@@ -147,10 +162,8 @@ public class GrpcClientAutoConfiguration {
     }
 
     @Bean
-    public EventExecutionRouter eventExecutionRouter(
-            @Value("${execution.mode:platform}") String executionMode
-    ) {
-        boolean useVirtual = "virtual".equals(executionMode);
+    public EventExecutionRouter eventExecutionRouter() {
+        boolean useVirtual = "virtual".equals(config.getExecutionMode());
 
         CalculationExecutionStrategy processorExecutor = new ProcessorThreadExecutor(useVirtual, config.getProcessorThreadPool());
         CalculationExecutionStrategy criteriaExecutor = new CriteriaThreadExecutor(useVirtual, config.getCriteriaThreadPool());

--- a/src/main/java/com/java_template/common/config/SecurityConfig.java
+++ b/src/main/java/com/java_template/common/config/SecurityConfig.java
@@ -3,12 +3,14 @@ package com.java_template.common.config;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
@@ -16,19 +18,22 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /**
- * ABOUTME: Spring Security configuration with externalized CORS settings.
- * CORS configuration is loaded from CorsProperties which supports environment-specific
- * settings via application.yml and environment variables.
+ * ABOUTME: Spring Boot auto-configuration providing permissive security and CORS defaults.
+ * Active only when no application-defined {@code SecurityFilterChain} / {@code CorsConfigurationSource} bean is present.
  *
- * <p>Security features:
- * <ul>
- *   <li>CORS configured via externalized properties (no hardcoded values)</li>
- *   <li>Validates that wildcards are not used with credentials</li>
- *   <li>Supports environment-specific configuration (dev/staging/prod)</li>
- * </ul>
+ * <p>This class is registered as auto-configuration so it is evaluated <em>after</em> all
+ * {@code @Configuration} beans in the application context. The {@code @ConditionalOnMissingBean}
+ * guards therefore work reliably: if the application supplies its own chain (e.g.
+ * {@code ApiSecurityConfig}) or its own CORS source, these defaults are silently skipped.
+ *
+ * <p>Default security policy: permit-all — suitable for local PoC development.
+ * Override by providing a {@code SecurityFilterChain} bean in your application package.
+ *
+ * <p>Default CORS policy: driven by {@code app.cors.*} properties (see {@link CorsProperties}).
+ * Override by providing a {@code CorsConfigurationSource} bean in your application package.
  */
-@Configuration
-@EnableWebSecurity
+@AutoConfiguration(before = SecurityAutoConfiguration.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @EnableConfigurationProperties(CorsProperties.class)
 public class SecurityConfig {
 
@@ -50,6 +55,7 @@ public class SecurityConfig {
     }
 
     @Bean
+    @ConditionalOnMissingBean(SecurityFilterChain.class)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             // Enable CORS with custom configuration
@@ -76,6 +82,7 @@ public class SecurityConfig {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = "corsConfigurationSource")
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 

--- a/src/main/java/com/java_template/common/exception/CyodaOperationException.java
+++ b/src/main/java/com/java_template/common/exception/CyodaOperationException.java
@@ -1,0 +1,38 @@
+package com.java_template.common.exception;
+
+/**
+ * Thrown when a Cyoda platform operation returns a failure response.
+ * Carries the error code, message, and retryable flag from the BaseEvent error payload.
+ */
+public class CyodaOperationException extends RuntimeException {
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final boolean retryable;
+
+    public CyodaOperationException(String errorCode, String errorMessage, Boolean retryable) {
+        super("Cyoda operation failed [" + errorCode + "]: " + errorMessage);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.retryable = Boolean.TRUE.equals(retryable);
+    }
+
+    public CyodaOperationException(String errorCode, String errorMessage, Boolean retryable, Throwable cause) {
+        super("Cyoda operation failed [" + errorCode + "]: " + errorMessage, cause);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.retryable = Boolean.TRUE.equals(retryable);
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public boolean isRetryable() {
+        return retryable;
+    }
+}

--- a/src/main/java/com/java_template/common/grpc/client/ClientAuthorizationInterceptor.java
+++ b/src/main/java/com/java_template/common/grpc/client/ClientAuthorizationInterceptor.java
@@ -1,6 +1,7 @@
 package com.java_template.common.grpc.client;
 
 import com.java_template.common.auth.Authentication;
+import com.java_template.common.auth.OboTokenException;
 import io.grpc.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,16 +27,26 @@ public class ClientAuthorizationInterceptor implements ClientInterceptor {
             @Override
             public void start(Listener<RespT> responseListener, Metadata headers) {
                 try {
-                    // pull the access token from the authentication service.
-                    // This will re-use an existing cached token if it is still valid for a short period (minute)
                     OAuth2AccessToken accessToken = authentication.getAccessToken();
-                    String freshToken = accessToken.getTokenValue();
                     Metadata.Key<String> authKey = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
-                    headers.put(authKey, "Bearer " + freshToken);
+                    headers.put(authKey, "Bearer " + accessToken.getTokenValue());
+
+                } catch (OboTokenException e) {
+                    LOG.error("OBO token exchange failed — cancelling Cyoda call: {}", e.getMessage(), e);
+                    responseListener.onClose(
+                            Status.UNAUTHENTICATED
+                                    .withDescription("OBO token exchange failed: " + e.getMessage())
+                                    .withCause(e),
+                            new Metadata()
+                    );
+                    return;
+
                 } catch (ClientAuthorizationException e) {
-                    LOG.error("Failed to get access token. Will not set the Bearer Token {}", e.getError().getDescription());
+                    LOG.error("M2M token unavailable — proceeding without auth header: {}",
+                            e.getError().getDescription());
+
                 } catch (Exception e) {
-                    LOG.error("Failed to get access token. Will not set the Bearer Token", e);
+                    LOG.error("Unexpected error obtaining access token — proceeding without auth header", e);
                 }
                 super.start(responseListener, headers);
             }

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/AbstractEventStrategy.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/AbstractEventStrategy.java
@@ -3,6 +3,10 @@ package com.java_template.common.grpc.client.event_handling;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java_template.common.auth.EventAuthContextHandler;
+import com.java_template.common.auth.EventAuthContextMissingException;
+import com.java_template.common.auth.EventAuthContextScope;
+import com.java_template.common.auth.EventUserResolutionException;
 import com.java_template.common.workflow.CyodaContextFactory;
 import com.java_template.common.workflow.CyodaEventContext;
 import com.java_template.common.workflow.OperationFactory;
@@ -34,15 +38,18 @@ public abstract class AbstractEventStrategy<
     protected final OperationFactory operationFactory;
     protected final ObjectMapper objectMapper;
     protected final CyodaContextFactory eventContextFactory;
+    private final EventAuthContextHandler authContextHandler;
 
     protected AbstractEventStrategy(
             OperationFactory operationFactory,
             ObjectMapper objectMapper,
-            CyodaContextFactory eventContextFactory
+            CyodaContextFactory eventContextFactory,
+            EventAuthContextHandler authContextHandler
     ) {
         this.operationFactory = operationFactory;
         this.objectMapper = objectMapper;
         this.eventContextFactory = eventContextFactory;
+        this.authContextHandler = authContextHandler;
     }
 
     /**
@@ -73,7 +80,16 @@ public abstract class AbstractEventStrategy<
 
             logger.debug("Running {} {}: {}", operation.getClass().getSimpleName(), cloudEventType, operationName);
 
-            return executeOperation(operation, request, context);
+            try (EventAuthContextScope ignored = authContextHandler.establish(cloudEvent)) {
+                return executeOperation(operation, request, context);
+            }
+
+        } catch (EventAuthContextMissingException e) {
+            logger.error("Auth context required but absent for {} event: {}", cloudEventType, e.getMessage());
+            return returnErrorResponseFor(request, e);
+        } catch (EventUserResolutionException e) {
+            logger.error("Cannot resolve user from auth context for {} event: {}", cloudEventType, e.getMessage());
+            return returnErrorResponseFor(request, e);
         } catch (Exception e) {
             logger.error("Error handling event: {}", cloudEvent, e);
             return returnErrorResponseFor(request, e);

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/AckEventStrategy.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/AckEventStrategy.java
@@ -41,8 +41,8 @@ public class AckEventStrategy implements EventHandlingStrategy<BaseEvent> {
                 cloudEvent.getTextData()
         );
 
-        cloudEventParser.parseCloudEvent(cloudEvent, EventAckResponse.class)
-                .ifPresent(eventTracker::trackAcknowledgeReceived);
+        EventAckResponse ackResponse = cloudEventParser.parseCloudEvent(cloudEvent, EventAckResponse.class);
+        eventTracker.trackAcknowledgeReceived(ackResponse);
 
         return null;
     }

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/CloudEventParser.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/CloudEventParser.java
@@ -2,20 +2,17 @@ package com.java_template.common.grpc.client.event_handling;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java_template.common.exception.CyodaOperationException;
 import io.cloudevents.v1.proto.CloudEvent;
-import java.util.Optional;
 import org.cyoda.cloud.api.event.common.BaseEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * ABOUTME: Component for parsing CloudEvent instances into BaseEvent objects
- * with JSON deserialization and error handling capabilities.
+ * Parses CloudEvent gRPC responses into typed BaseEvent subclasses.
+ * Throws CyodaOperationException if the response cannot be deserialized.
  */
 @Component
 public class CloudEventParser {
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private final ObjectMapper objectMapper;
 
@@ -23,25 +20,19 @@ public class CloudEventParser {
         this.objectMapper = objectMapper;
     }
 
-    public <EVENT_TYPE extends BaseEvent> Optional<EVENT_TYPE> parseCloudEvent(
+    public <EVENT_TYPE extends BaseEvent> EVENT_TYPE parseCloudEvent(
             CloudEvent cloudEvent,
             Class<EVENT_TYPE> clazz
     ) {
         try {
-            return Optional.of(
-                    objectMapper.readValue(
-                        cloudEvent.getTextData(),
-                        clazz
-                    )
-            );
+            return objectMapper.readValue(cloudEvent.getTextData(), clazz);
         } catch (JsonProcessingException e) {
-            log.error(
-                    "Error parsing cloud event. This shouldn't happen unless the systems are misaligned {}",
-                    cloudEvent,
+            throw new CyodaOperationException(
+                    "PARSE_ERROR",
+                    "Failed to parse Cyoda response: " + e.getMessage(),
+                    false,
                     e
             );
-            return Optional.empty();
         }
     }
-
 }

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/CriteriaEventStrategy.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/CriteriaEventStrategy.java
@@ -2,6 +2,7 @@ package com.java_template.common.grpc.client.event_handling;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java_template.common.auth.EventAuthContextHandler;
 import com.java_template.common.workflow.*;
 import org.cyoda.cloud.api.event.common.CloudEventType;
 import org.cyoda.cloud.api.event.common.EntityMetadata;
@@ -25,9 +26,10 @@ public class CriteriaEventStrategy extends AbstractEventStrategy<
     public CriteriaEventStrategy(
             OperationFactory operationFactory,
             ObjectMapper objectMapper,
-            CyodaContextFactory eventContextFactory
+            CyodaContextFactory eventContextFactory,
+            EventAuthContextHandler authContextHandler
     ) {
-        super(operationFactory, objectMapper, eventContextFactory);
+        super(operationFactory, objectMapper, eventContextFactory, authContextHandler);
     }
 
     @Override

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/GreetEventStrategy.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/GreetEventStrategy.java
@@ -49,8 +49,8 @@ public class GreetEventStrategy implements EventHandlingStrategy<BaseEvent>, Gre
 
         log.debug("[IN] Received event {}: \n{}", cloudEventType, cloudEvent.getTextData());
 
-        cloudEventParser.parseCloudEvent(cloudEvent, CalculationMemberGreetEvent.class)
-                .ifPresent(event -> log.info("Received greet event: {}", event));
+        CalculationMemberGreetEvent event = cloudEventParser.parseCloudEvent(cloudEvent, CalculationMemberGreetEvent.class);
+        log.info("Received greet event: {}", event);
 
         return null;
     }

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/KeepAliveEventHandlingStrategy.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/KeepAliveEventHandlingStrategy.java
@@ -33,15 +33,7 @@ public class KeepAliveEventHandlingStrategy implements EventHandlingStrategy<Eve
     @Override
     public EventAckResponse handleEvent(@NotNull final CloudEvent cloudEvent) {
         eventTracker.trackKeepAlive(System.currentTimeMillis());
-        final var resp = cloudEventParser.parseCloudEvent(
-                cloudEvent,
-                EventAckResponse.class
-        ).orElse(null);
-
-        if (resp == null) {
-            return null;
-        }
-
+        final var resp = cloudEventParser.parseCloudEvent(cloudEvent, EventAckResponse.class);
         resp.setSourceEventId(resp.getId());
         return resp;
     }

--- a/src/main/java/com/java_template/common/grpc/client/event_handling/ProcessorEventStrategy.java
+++ b/src/main/java/com/java_template/common/grpc/client/event_handling/ProcessorEventStrategy.java
@@ -2,6 +2,7 @@ package com.java_template.common.grpc.client.event_handling;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java_template.common.auth.EventAuthContextHandler;
 import com.java_template.common.workflow.*;
 import org.cyoda.cloud.api.event.common.CloudEventType;
 import org.cyoda.cloud.api.event.common.EntityMetadata;
@@ -25,9 +26,10 @@ public class ProcessorEventStrategy extends AbstractEventStrategy<
     public ProcessorEventStrategy(
             OperationFactory operationFactory,
             ObjectMapper objectMapper,
-            CyodaContextFactory eventContextFactory
+            CyodaContextFactory eventContextFactory,
+            EventAuthContextHandler authContextHandler
     ) {
-        super(operationFactory, objectMapper, eventContextFactory);
+        super(operationFactory, objectMapper, eventContextFactory, authContextHandler);
     }
 
     @Override

--- a/src/main/java/com/java_template/common/grpc/client/monitoring/GrpcConnectionMonitor.java
+++ b/src/main/java/com/java_template/common/grpc/client/monitoring/GrpcConnectionMonitor.java
@@ -3,12 +3,14 @@ package com.java_template.common.grpc.client.monitoring;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.java_template.common.config.Config;
+import com.java_template.common.observability.StreamObservabilityListener;
 import io.cloudevents.v1.proto.CloudEvent;
 import io.grpc.ConnectivityState;
 import org.cyoda.cloud.api.event.common.CloudEventType;
 import org.cyoda.cloud.api.event.processing.EventAckResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -43,9 +45,12 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
 
     private final Config config;
     private final Cache<String, CloudEvent> sentEventsCache;
+    @Nullable
+    private final StreamObservabilityListener observabilityListener;
 
-    public GrpcConnectionMonitor(Config config) {
+    public GrpcConnectionMonitor(Config config, @Nullable StreamObservabilityListener observabilityListener) {
         this.config = config;
+        this.observabilityListener = observabilityListener;
         this.sentEventsCache = Caffeine.newBuilder()
                 .maximumSize(config.getSentEventsCacheMaxSize())
                 .expireAfterWrite(5, TimeUnit.MINUTES)
@@ -81,7 +86,9 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
 
     private static final Set<String> EVENT_TYPES_TO_IGNORE = Set.of(
                     CloudEventType.EVENT_ACK_RESPONSE,
-                    CloudEventType.CALCULATION_MEMBER_JOIN_EVENT
+                    CloudEventType.CALCULATION_MEMBER_JOIN_EVENT,
+                    CloudEventType.ENTITY_PROCESSOR_CALCULATION_RESPONSE,
+                    CloudEventType.ENTITY_CRITERIA_CALCULATION_RESPONSE
             ).stream()
             .map(Enum::toString)
             .collect(Collectors.toSet());
@@ -92,10 +99,16 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
             sentEventsCache.put(cloudEvent.getId(), cloudEvent);
             logger.debug("Cached sent event '{}':'{}'", cloudEvent.getType(), cloudEvent.getId());
         }
+        if (observabilityListener != null) {
+            observabilityListener.onEventSent();
+        }
     }
 
     @Override
     public void trackAcknowledgeReceived(final EventAckResponse acknowledgeResponse) {
+        if (observabilityListener != null) {
+            observabilityListener.onAckReceived();
+        }
         final var ackId = acknowledgeResponse.getId();
         final var sourceEventId = acknowledgeResponse.getSourceEventId();
         final var success = acknowledgeResponse.getSuccess();
@@ -129,6 +142,9 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
     @Override
     public void trackKeepAlive(final Long eventTimestamp) {
         lastKeepAliveTimestampMs.set(eventTimestamp);
+        if (observabilityListener != null) {
+            observabilityListener.onKeepAlive(eventTimestamp);
+        }
     }
 
     @Override
@@ -155,13 +171,30 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
 
     private void checkSentEventsCacheSize() {
         int maxSize = config.getSentEventsCacheMaxSize();
-        if (sentEventsCache.estimatedSize() > maxSize / 10) {
-            logger.warn("Sent events cache is growing. Current size: {}", sentEventsCache.estimatedSize());
-        } else if (sentEventsCache.estimatedSize() > maxSize / 2) {
+        if (sentEventsCache.estimatedSize() > maxSize / 2) {
             logger.error("Sent events cache is growing unchecked. Current size: {}", sentEventsCache.estimatedSize());
+            if (logger.isTraceEnabled()) {
+                logUnacknowledgedEventDetails();
+            }
+        } else if (sentEventsCache.estimatedSize() > maxSize / 10) {
+            logger.warn("Sent events cache is growing. Current size: {}", sentEventsCache.estimatedSize());
+            if (logger.isTraceEnabled()) {
+                logUnacknowledgedEventDetails();
+            }
         } else {
             logger.debug("Sent events cache size: {}", sentEventsCache.estimatedSize());
         }
+    }
+
+    private void logUnacknowledgedEventDetails() {
+        var pending = sentEventsCache.asMap();
+        var countsByType = pending.values().stream()
+                .collect(Collectors.groupingBy(CloudEvent::getType, Collectors.counting()));
+        logger.trace("Unacknowledged events by type: {}", countsByType);
+        pending.forEach((id, event) ->
+                logger.trace("  Pending event id='{}' type='{}' source='{}'",
+                        id, event.getType(), event.getSource())
+        );
     }
 
     private void checkTimeSinceLastKeepAlive() {
@@ -176,7 +209,7 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
         }
 
         final var timeSinceLastKeepAlive = System.currentTimeMillis() - lastKeepAliveTimestampMs;
-        logger.debug("{}ms since last keep alive", timeSinceLastKeepAlive);
+        logger.debug("{} ms since last keep alive", timeSinceLastKeepAlive);
 
         long threshold = config.getKeepAliveWarningThreshold();
         if (timeSinceLastKeepAlive > threshold) {
@@ -199,6 +232,14 @@ public class GrpcConnectionMonitor implements EventTracker, ConnectionStateTrack
                 newState,
                 lastConnectionState.get()
         );
+        if (observabilityListener != null) {
+            switch (newState) {
+                case READY -> observabilityListener.onStreamOpen();
+                case DISCONNECTED -> observabilityListener.onStreamClose();
+                case ERROR -> observabilityListener.onStreamError();
+                default -> { }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/java_template/common/observability/GrpcObservabilityInterceptor.java
+++ b/src/main/java/com/java_template/common/observability/GrpcObservabilityInterceptor.java
@@ -1,0 +1,66 @@
+package com.java_template.common.observability;
+
+import io.grpc.*;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+
+/**
+ * ABOUTME: gRPC ClientInterceptor that creates OpenTelemetry spans for outgoing Cyoda gRPC calls.
+ * Records the full method name as the span name and rpc.method attribute, tracks gRPC status
+ * codes as a counter, and marks spans as ERROR when a call closes with a non-OK status.
+ */
+public class GrpcObservabilityInterceptor implements ClientInterceptor {
+
+    private static final AttributeKey<String> RPC_METHOD_KEY = AttributeKey.stringKey("rpc.method");
+    private static final AttributeKey<Long> GRPC_STATUS_CODE_KEY = AttributeKey.longKey("rpc.grpc.status_code");
+    private static final AttributeKey<String> STATUS_CODE_NAME_KEY = AttributeKey.stringKey("status_code");
+    private static final AttributeKey<String> METHOD_KEY = AttributeKey.stringKey("method");
+
+    private final Tracer tracer;
+    private final LongCounter grpcStatusCounter;
+
+    public GrpcObservabilityInterceptor(OpenTelemetry openTelemetry) {
+        this.tracer = openTelemetry.getTracer("com.java_template.common.observability");
+        Meter meter = openTelemetry.getMeter("com.java_template.common.observability");
+        this.grpcStatusCounter = meter.counterBuilder("cyoda.grpc.status")
+                .setDescription("gRPC call outcomes by method and status code")
+                .build();
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+
+        String fullMethodName = method.getFullMethodName();
+        Span span = tracer.spanBuilder("gRPC " + fullMethodName)
+                .setAttribute(RPC_METHOD_KEY, fullMethodName)
+                .startSpan();
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<>(responseListener) {
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        span.setAttribute(GRPC_STATUS_CODE_KEY, (long) status.getCode().value());
+                        grpcStatusCounter.add(1, Attributes.of(
+                                METHOD_KEY, fullMethodName,
+                                STATUS_CODE_NAME_KEY, status.getCode().name()
+                        ));
+                        if (!status.isOk()) {
+                            span.setStatus(StatusCode.ERROR, status.getDescription());
+                        }
+                        span.end();
+                        super.onClose(status, trailers);
+                    }
+                }, headers);
+            }
+        };
+    }
+}

--- a/src/main/java/com/java_template/common/observability/ObservabilityAutoConfiguration.java
+++ b/src/main/java/com/java_template/common/observability/ObservabilityAutoConfiguration.java
@@ -1,0 +1,34 @@
+package com.java_template.common.observability;
+
+import io.opentelemetry.api.OpenTelemetry;
+import com.java_template.common.grpc.client.event_handling.EventHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * ABOUTME: Auto-configuration that registers observability beans (event handler decorator,
+ * gRPC interceptor, stream listener) conditionally when the OTel agent provides an OpenTelemetry bean.
+ * When the OTel agent is not attached, these beans are not created and the app runs as before.
+ */
+@Configuration
+@ConditionalOnBean(OpenTelemetry.class)
+public class ObservabilityAutoConfiguration {
+
+    @Bean
+    public GrpcObservabilityInterceptor grpcObservabilityInterceptor(OpenTelemetry openTelemetry) {
+        return new GrpcObservabilityInterceptor(openTelemetry);
+    }
+
+    @Bean
+    public StreamObservabilityListener streamObservabilityListener(OpenTelemetry openTelemetry) {
+        return new StreamObservabilityListener(openTelemetry);
+    }
+
+    @Bean
+    @Primary
+    public EventHandler observableEventHandler(EventHandler delegate, OpenTelemetry openTelemetry) {
+        return new ObservableEventHandler(delegate, openTelemetry);
+    }
+}

--- a/src/main/java/com/java_template/common/observability/ObservableEventHandler.java
+++ b/src/main/java/com/java_template/common/observability/ObservableEventHandler.java
@@ -1,0 +1,81 @@
+package com.java_template.common.observability;
+
+import com.java_template.common.grpc.client.event_handling.EventHandler;
+import io.cloudevents.v1.proto.CloudEvent;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+
+import java.util.Set;
+
+/**
+ * ABOUTME: Decorator that wraps an EventHandler with OpenTelemetry spans and metrics.
+ * Creates a span per CloudEvent processed, records event type and ID as attributes,
+ * and tracks duration histograms and event/error counters.
+ */
+public class ObservableEventHandler implements EventHandler {
+
+    private static final AttributeKey<String> EVENT_TYPE_KEY = AttributeKey.stringKey("cyoda.event.type");
+    private static final AttributeKey<String> EVENT_ID_KEY = AttributeKey.stringKey("cyoda.event.id");
+    private static final AttributeKey<String> OUTCOME_KEY = AttributeKey.stringKey("outcome");
+    private static final AttributeKey<String> EXCEPTION_CLASS_KEY = AttributeKey.stringKey("exception_class");
+
+    private final EventHandler delegate;
+    private final Tracer tracer;
+    private final DoubleHistogram eventDuration;
+    private final LongCounter eventCount;
+    private final LongCounter eventErrors;
+
+    public ObservableEventHandler(EventHandler delegate, OpenTelemetry openTelemetry) {
+        this.delegate = delegate;
+        this.tracer = openTelemetry.getTracer("com.java_template.common.observability");
+
+        Meter meter = openTelemetry.getMeter("com.java_template.common.observability");
+        this.eventDuration = meter.histogramBuilder("cyoda.event.duration")
+                .setDescription("CloudEvent processing duration in seconds")
+                .setUnit("s")
+                .build();
+        this.eventCount = meter.counterBuilder("cyoda.event.count")
+                .setDescription("Total CloudEvents processed")
+                .build();
+        this.eventErrors = meter.counterBuilder("cyoda.event.errors")
+                .setDescription("Total CloudEvent processing failures")
+                .build();
+    }
+
+    @Override
+    public void handleEvent(CloudEvent cloudEvent) {
+        String eventType = cloudEvent.getType();
+        Span span = tracer.spanBuilder("cyoda.event " + eventType)
+                .setAttribute(EVENT_TYPE_KEY, eventType)
+                .setAttribute(EVENT_ID_KEY, cloudEvent.getId())
+                .startSpan();
+
+        long startNanos = System.nanoTime();
+        try (var scope = span.makeCurrent()) {
+            delegate.handleEvent(cloudEvent);
+            eventCount.add(1, Attributes.of(EVENT_TYPE_KEY, eventType, OUTCOME_KEY, "success"));
+        } catch (Exception e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
+            eventCount.add(1, Attributes.of(EVENT_TYPE_KEY, eventType, OUTCOME_KEY, "error"));
+            eventErrors.add(1, Attributes.of(EVENT_TYPE_KEY, eventType, EXCEPTION_CLASS_KEY, e.getClass().getName()));
+            throw e;
+        } finally {
+            double durationSeconds = (System.nanoTime() - startNanos) / 1_000_000_000.0;
+            eventDuration.record(durationSeconds, Attributes.of(EVENT_TYPE_KEY, eventType));
+            span.end();
+        }
+    }
+
+    @Override
+    public Set<String> getSupportedTags() {
+        return delegate.getSupportedTags();
+    }
+}

--- a/src/main/java/com/java_template/common/observability/StreamObservabilityListener.java
+++ b/src/main/java/com/java_template/common/observability/StreamObservabilityListener.java
@@ -1,0 +1,78 @@
+package com.java_template.common.observability;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * ABOUTME: Tracks gRPC bidirectional stream lifecycle metrics using OpenTelemetry gauges.
+ * Records active stream count, seconds since last keep-alive heartbeat, and the number
+ * of sent events awaiting acknowledgement.
+ */
+public class StreamObservabilityListener {
+
+    private final AtomicLong activeStreams = new AtomicLong(0);
+    private final AtomicLong lastKeepAliveMs = new AtomicLong(0);
+    private final AtomicLong pendingAcks = new AtomicLong(0);
+
+    public StreamObservabilityListener(OpenTelemetry openTelemetry) {
+        Meter meter = openTelemetry.getMeter("com.java_template.common.observability");
+
+        meter.gaugeBuilder("cyoda.grpc.stream.active")
+                .ofLongs()
+                .setDescription("Number of active gRPC bidirectional streams")
+                .buildWithCallback(measurement -> measurement.record(activeStreams.get()));
+
+        meter.gaugeBuilder("cyoda.grpc.keepalive.age")
+                .ofLongs()
+                .setDescription("Seconds since the last gRPC keep-alive heartbeat was received")
+                .buildWithCallback(measurement -> {
+                    long last = lastKeepAliveMs.get();
+                    if (last == 0) {
+                        measurement.record(0);
+                    } else {
+                        measurement.record((System.currentTimeMillis() - last) / 1000);
+                    }
+                });
+
+        meter.gaugeBuilder("cyoda.grpc.ack.pending")
+                .ofLongs()
+                .setDescription("Number of sent events awaiting acknowledgement")
+                .buildWithCallback(measurement -> measurement.record(pendingAcks.get()));
+    }
+
+    /** Called when a new gRPC bidirectional stream is opened. */
+    public void onStreamOpen() {
+        activeStreams.incrementAndGet();
+    }
+
+    /** Called when a gRPC stream closes normally. */
+    public void onStreamClose() {
+        activeStreams.decrementAndGet();
+    }
+
+    /** Called when a gRPC stream closes due to an error. */
+    public void onStreamError() {
+        activeStreams.decrementAndGet();
+    }
+
+    /**
+     * Called when a keep-alive heartbeat is received.
+     *
+     * @param timestampMs the wall-clock time of the heartbeat in epoch milliseconds
+     */
+    public void onKeepAlive(long timestampMs) {
+        lastKeepAliveMs.set(timestampMs);
+    }
+
+    /** Called when an event is sent over the stream, incrementing the pending ACK count. */
+    public void onEventSent() {
+        pendingAcks.incrementAndGet();
+    }
+
+    /** Called when an ACK is received for a previously sent event, decrementing the pending count. */
+    public void onAckReceived() {
+        pendingAcks.decrementAndGet();
+    }
+}

--- a/src/main/java/com/java_template/common/repository/CyodaRepository.java
+++ b/src/main/java/com/java_template/common/repository/CyodaRepository.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Streams;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.java_template.common.config.Config;
 import com.java_template.common.dto.PageResult;
+import com.java_template.common.exception.CyodaOperationException;
 import com.java_template.common.grpc.client.event_handling.CloudEventBuilder;
 import com.java_template.common.grpc.client.event_handling.CloudEventParser;
 import io.cloudevents.v1.proto.CloudEvent;
@@ -27,6 +28,9 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.IOException;
 import java.util.*;
@@ -125,7 +129,7 @@ public class CyodaRepository implements CrudRepository {
 
     private CompletableFuture<DataPayload> getById(final UUID entityId, @Nullable final Date pointInTime) {
         return sendAndGet(
-                cloudEventsServiceBlockingStub::entityManage,
+                cloudEventsServiceBlockingStub::entitySearch,
                 new EntityGetRequest().withId(UUID.randomUUID().toString())
                         .withEntityId(entityId)
                         .withPointInTime(pointInTime),
@@ -166,8 +170,11 @@ public class CyodaRepository implements CrudRepository {
 
         return snapshot.thenComposeAsync(snapshotInfo -> {
                     if (snapshotInfo.getSnapshotId() == null) {
-                        logger.error("Snapshot ID not found in response");
-                        return CompletableFuture.completedFuture(null);
+                        throw new CyodaOperationException(
+                                "MISSING_SNAPSHOT_ID",
+                                "Snapshot search returned no snapshot ID",
+                                false
+                        );
                     }
 
                     // Use the snapshot ID from Cyoda as the search ID
@@ -246,7 +253,9 @@ public class CyodaRepository implements CrudRepository {
                 .operator(GroupOperatorDto.AND)
                 .conditions(List.of());
 
-        return findAllByCondition(modelSpec, params.pageSize(), params.pageNumber(), matchAllCondition, params.pointInTime(), params.searchId(), params.awaitLimitMs(), params.pollIntervalMs());
+        return params.inMemory()
+                ? findAllByConditionInMemory(modelSpec, params.pageSize(), matchAllCondition, params.pointInTime())
+                : findAllByCondition(modelSpec, params.pageSize(), params.pageNumber(), matchAllCondition, params.pointInTime(), params.searchId(), params.awaitLimitMs(), params.pollIntervalMs());
     }
 
     @Override
@@ -367,9 +376,25 @@ public class CyodaRepository implements CrudRepository {
     ) {
         try {
             final CloudEvent requestEvent = cloudEventBuilder.buildEvent(baseEvent);
-            return CompletableFuture.supplyAsync(() -> requestAndGetOrThrow(apiCall, requestEvent))
+            // Capture the SecurityContext from the calling thread so that OboAwareAuthentication
+            // can perform the OBO token exchange on the ForkJoinPool thread that executes the gRPC call.
+            // Without this capture, CompletableFuture.supplyAsync() runs on a different thread whose
+            // ThreadLocal is empty, causing a silent fallback to the M2M service-account token.
+            final SecurityContext callerContext = SecurityContextHolder.getContext();
+            return CompletableFuture.supplyAsync(() -> {
+                        SecurityContext previous = SecurityContextHolder.getContext();
+                        SecurityContextHolder.setContext(callerContext);
+                        try {
+                            logger.debug("Sending event: {}", requestEvent);
+                            CloudEvent cloudEvent = requestAndGetOrThrow(apiCall, requestEvent);
+                            logger.debug("Received event: {}", cloudEvent);
+                            return cloudEvent;
+                        } finally {
+                            SecurityContextHolder.setContext(previous);
+                        }
+                    })
                     .thenApply(response -> cloudEventParser.parseCloudEvent(response, responsePayloadType))
-                    .thenApply(this::getOrNull);
+                    .thenApply(this::validateResponse);
         } catch (InvalidProtocolBufferException e) {
             throw new RuntimeException(e);
         }
@@ -382,7 +407,17 @@ public class CyodaRepository implements CrudRepository {
     ) {
         try {
             final var requestEvent = cloudEventBuilder.buildEvent(baseEvent);
-            return CompletableFuture.supplyAsync(() -> requestAndGetOrThrow(apiCall, requestEvent))
+            // Same context-capture pattern as sendAndGet — see comment there.
+            final SecurityContext callerContext = SecurityContextHolder.getContext();
+            return CompletableFuture.supplyAsync(() -> {
+                        SecurityContext previous = SecurityContextHolder.getContext();
+                        SecurityContextHolder.setContext(callerContext);
+                        try {
+                            return requestAndGetOrThrow(apiCall, requestEvent);
+                        } finally {
+                            SecurityContextHolder.setContext(previous);
+                        }
+                    })
                     .thenApply(response -> processCollection(Streams.stream(response), responsePayloadClass));
         } catch (InvalidProtocolBufferException e) {
             throw new RuntimeException(e);
@@ -393,16 +428,10 @@ public class CyodaRepository implements CrudRepository {
             final Stream<CloudEvent> stream,
             final Class<RESPONSE_PAYLOAD_TYPE> payloadType
     ) {
+        // Filter null CloudEvent entries that may arrive from the gRPC streaming iterator
         return stream.filter(Objects::nonNull)
                 .map(elm -> cloudEventParser.parseCloudEvent(elm, payloadType))
-                .map(this::getOrNull)
-                .filter(Objects::nonNull);
-    }
-
-    private <RESPONSE_PAYLOAD_TYPE extends BaseEvent> RESPONSE_PAYLOAD_TYPE getOrNull(
-            final Optional<RESPONSE_PAYLOAD_TYPE> event
-    ) {
-        return event.orElse(null);
+                .map(this::validateResponse);
     }
 
     private <RESPONSE_PAYLOAD_TYPE> RESPONSE_PAYLOAD_TYPE requestAndGetOrThrow(
@@ -414,6 +443,24 @@ public class CyodaRepository implements CrudRepository {
         } catch (Exception e) {
             throw new CompletionException(e);
         }
+    }
+
+    /**
+     * Validates a Cyoda response: logs any warnings, then throws if the operation failed.
+     * Package-private to allow direct unit testing without mocking the full gRPC pipeline.
+     */
+    <T extends BaseEvent> T validateResponse(T response) {
+        if (response.getWarnings() != null && !response.getWarnings().isEmpty()) {
+            response.getWarnings().forEach(w -> logger.warn("Cyoda warning: {}", w));
+        }
+        if (Boolean.FALSE.equals(response.getSuccess())) {
+            org.cyoda.cloud.api.event.common.Error error = response.getError();
+            String code = error != null ? error.getCode() : "UNKNOWN";
+            String message = error != null ? error.getMessage() : "Operation failed with no error details";
+            boolean retryable = error != null ? Optional.ofNullable(error.getRetryable()).orElse(false) : false;
+            throw new CyodaOperationException(code, message, retryable);
+        }
+        return response;
     }
 
     private <PAYLOAD_TYPE> CompletableFuture<EntityTransactionResponse> saveNewEntities(

--- a/src/main/java/com/java_template/common/service/EdgeMessageService.java
+++ b/src/main/java/com/java_template/common/service/EdgeMessageService.java
@@ -3,8 +3,8 @@ package com.java_template.common.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 

--- a/src/main/java/com/java_template/common/service/EdgeMessageServiceImpl.java
+++ b/src/main/java/com/java_template/common/service/EdgeMessageServiceImpl.java
@@ -6,9 +6,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.java_template.common.auth.Authentication;
+import com.java_template.common.config.Config;
 import com.java_template.common.util.HttpUtils;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,12 +35,12 @@ public class EdgeMessageServiceImpl implements EdgeMessageService {
             HttpUtils httpUtils,
             Authentication authentication,
             ObjectMapper objectMapper,
-            @Value("${cyoda.api.url}") String cyodaApiUrl
+            Config configProperties
     ) {
         this.httpUtils = httpUtils;
         this.authentication = authentication;
         this.objectMapper = objectMapper;
-        this.cyodaApiUrl = cyodaApiUrl;
+        this.cyodaApiUrl = configProperties.getCyodaApiUrl();
     }
 
     @Override

--- a/src/main/java/com/java_template/common/service/EntityService.java
+++ b/src/main/java/com/java_template/common/service/EntityService.java
@@ -318,7 +318,7 @@ public interface EntityService {
      */
     java.util.Map<String, Long> getEntityStatsByState(
             @NotNull ModelSpec modelSpec,
-            @NotNull List<String> states,
+            @NotNull java.util.List<String> states,
             @Nullable java.util.Date pointInTime
     );
 

--- a/src/main/java/com/java_template/common/tool/CyodaInit.java
+++ b/src/main/java/com/java_template/common/tool/CyodaInit.java
@@ -12,15 +12,22 @@ import com.java_template.common.workflow.CyodaEntity;
 import org.cyoda.cloud.api.event.common.ModelSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.filter.AssignableTypeFilter;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,12 +40,15 @@ import java.util.stream.Stream;
  *<p>
  * This tool dynamically discovers entities and uses their getModelKey() method
  * to get the correct entity name and version instead of parsing file paths.
+ *<p>
+ * By default, entity classes are discovered by scanning the classpath and workflow
+ * JSON files are loaded from classpath resources under {@code /workflow/}. Both can
+ * be overridden with absolute filesystem paths via {@link CyodaInitConfig}.
  */
 @Component
 public class CyodaInit {
     private static final Logger logger = LoggerFactory.getLogger(CyodaInit.class);
-    private static final Path WORKFLOW_DTO_DIR = Paths.get(System.getProperty("user.dir")).resolve("src/main/resources/workflow");
-    private static final Path ENTITY_DIR = Paths.get(System.getProperty("user.dir")).resolve("src/main/java/com/java_template/application/entity");
+    private static final String CLASSPATH_WORKFLOW_PATTERN = "classpath:/workflow/**/*.json";
     public static final int THREAD_POOL_SIZE = 20;
 
     private final HttpUtils httpUtils;
@@ -66,27 +76,29 @@ public class CyodaInit {
 
 
     /**
-     * Initialize entities schema from discovered entities using their getModelKey() method
+     * Initialize entities schema from discovered entities using their getModelKey() method.
      */
     private void initEntitiesSchemaFromEntities(String token, CyodaInitConfig config) {
         logger.info("🔍 Discovering entities dynamically...");
 
-        List<ModelSpec> modelSpecs = discoverEntities();
+        List<ModelSpec> modelSpecs = config.entitySourceDir() != null
+                ? discoverEntitiesFromSourceDir(Paths.get(config.entitySourceDir()))
+                : discoverEntitiesFromClasspath();
+
         logger.info("🔍 Discovered {} entities: {}", modelSpecs.size(),
                 modelSpecs.stream().map(spec -> spec.getName() + ":" + spec.getVersion()).toList());
 
-        // Process workflows in parallel for better performance
         ExecutorService executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
         try {
             List<CompletableFuture<Void>> futures = new ArrayList<>();
 
             for (ModelSpec modelSpec : modelSpecs) {
-                Path workflowFile = findWorkflowFile(WORKFLOW_DTO_DIR, modelSpec.getName(), modelSpec.getVersion());
-                if (workflowFile != null) {
-                    logger.info("✅ Found workflow file for {}: {}", modelSpec.getName(), workflowFile);
-
+                Optional<String> workflowJson = loadWorkflowJson(config, modelSpec.getName(), modelSpec.getVersion());
+                if (workflowJson.isPresent()) {
+                    logger.info("✅ Found workflow for entity: {} (version: {})", modelSpec.getName(), modelSpec.getVersion());
+                    final String json = workflowJson.get();
                     CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
-                                    importWorkflowForEntity(workflowFile, modelSpec.getName(), modelSpec.getVersion(), token, config),
+                                    importWorkflowForEntity(json, modelSpec.getName(), modelSpec.getVersion(), token, config),
                             executor
                     );
                     futures.add(future);
@@ -95,7 +107,6 @@ public class CyodaInit {
                 }
             }
 
-            // Wait for all imports to complete
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
         } finally {
             executor.shutdown();
@@ -104,67 +115,140 @@ public class CyodaInit {
 
 
     /**
-     * Discover entities from the entity directory and return their ModelSpec information
+     * Discover entities by scanning the classpath for {@link CyodaEntity} implementations.
+     * This is the default mode and works in both IDE and packaged JAR environments.
      */
-    private List<ModelSpec> discoverEntities() {
+    private List<ModelSpec> discoverEntitiesFromClasspath() {
         List<ModelSpec> modelSpecs = new ArrayList<>();
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AssignableTypeFilter(CyodaEntity.class));
 
-        if (!Files.exists(ENTITY_DIR)) {
-            logger.warn("📁 Entity directory '{}' does not exist", ENTITY_DIR);
-            return modelSpecs;
-        }
-
-        try (Stream<Path> javaFiles = Files.walk(ENTITY_DIR)) {
-            List<Path> entityFiles = javaFiles
-                    .filter(path -> path.toString().endsWith(".java"))
-                    .filter(path -> !path.getFileName().toString().startsWith("Test"))
-                    .toList();
-
-            for (Path javaFile : entityFiles) {
-                ModelSpec modelSpec = extractEntityModelSpec(javaFile);
-                if (modelSpec != null) {
-                    modelSpecs.add(modelSpec);
-                    logger.debug("✅ Discovered entity: {} (version: {})", modelSpec.getName(), modelSpec.getVersion());
-                }
+        for (BeanDefinition bd : scanner.findCandidateComponents(config.getEntityBasePackage())) {
+            ModelSpec spec = loadModelSpecFromClassName(bd.getBeanClassName());
+            if (spec != null) {
+                modelSpecs.add(spec);
+                logger.debug("✅ Discovered entity from classpath: {} (version: {})", spec.getName(), spec.getVersion());
             }
-        } catch (IOException e) {
-            logger.error("❌ Error scanning entity directory: {}", e.getMessage(), e);
         }
 
         return modelSpecs;
     }
 
     /**
-     * Extract ModelSpec from entity class by loading it and calling getModelKey()
+     * Discover entities by scanning {@code .java} source files in the given directory.
+     * Used when {@code --entity-source-dir} is specified in {@link CyodaInitConfig}.
      */
-    private ModelSpec extractEntityModelSpec(Path javaFile) {
-        try {
-            // Convert file path to class name
-            String relativePath = ENTITY_DIR.relativize(javaFile).toString();
-            String className = relativePath.replace(File.separator, ".")
-                    .replace(".java", "");
-            String fullClassName = "com.java_template.application.entity." + className;
+    private List<ModelSpec> discoverEntitiesFromSourceDir(Path entityDir) {
+        List<ModelSpec> modelSpecs = new ArrayList<>();
 
-            // Load the class
-            Class<?> clazz = Class.forName(fullClassName);
+        if (!Files.exists(entityDir)) {
+            logger.warn("📁 Entity source directory '{}' does not exist", entityDir);
+            return modelSpecs;
+        }
 
-            // Check if it implements CyodaEntity
-            if (!CyodaEntity.class.isAssignableFrom(clazz)) {
-                return null; // Skip non-entity classes
+        try (Stream<Path> javaFiles = Files.walk(entityDir)) {
+            List<Path> entityFiles = javaFiles
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> !path.getFileName().toString().startsWith("Test"))
+                    .toList();
+
+            for (Path javaFile : entityFiles) {
+                String relativePath = entityDir.relativize(javaFile).toString();
+                String className = relativePath.replace(File.separator, ".").replace(".java", "");
+                ModelSpec spec = loadModelSpecFromClassName(config.getEntityBasePackage() + "." + className);
+                if (spec != null) {
+                    modelSpecs.add(spec);
+                    logger.debug("✅ Discovered entity from source dir: {} (version: {})", spec.getName(), spec.getVersion());
+                }
             }
+        } catch (IOException e) {
+            logger.error("❌ Error scanning entity source directory: {}", e.getMessage(), e);
+        }
 
-            // Create instance and get model information
+        return modelSpecs;
+    }
+
+    /**
+     * Load a {@link ModelSpec} from a fully-qualified class name.
+     * Returns {@code null} for non-entity classes or on any error.
+     */
+    private ModelSpec loadModelSpecFromClassName(String fullClassName) {
+        try {
+            Class<?> clazz = Class.forName(fullClassName);
+            if (!CyodaEntity.class.isAssignableFrom(clazz)) {
+                return null;
+            }
             CyodaEntity entity = (CyodaEntity) clazz.getDeclaredConstructor().newInstance();
             return entity.getModelKey().modelKey();
-
         } catch (Exception e) {
-            logger.debug("Could not load entity class from {}: {}", javaFile, e.getMessage());
+            logger.debug("Could not load entity class {}: {}", fullClassName, e.getMessage());
             return null;
         }
     }
 
     /**
-     * Find workflow file for the given entity name and version
+     * Load workflow JSON for the given entity and version.
+     * Uses classpath resources by default; uses the filesystem directory from
+     * {@link CyodaInitConfig#workflowDir()} when that option is set.
+     */
+    private Optional<String> loadWorkflowJson(CyodaInitConfig config, String entityName, Integer version) {
+        if (config.workflowDir() != null) {
+            return loadWorkflowJsonFromDir(Paths.get(config.workflowDir()), entityName, version);
+        }
+        return loadWorkflowJsonFromClasspath(entityName, version);
+    }
+
+    /**
+     * Load workflow JSON from classpath resources matching {@code /workflow/**}/{@code *.json}.
+     */
+    private Optional<String> loadWorkflowJsonFromClasspath(String entityName, Integer version) {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource[] resources = resolver.getResources(CLASSPATH_WORKFLOW_PATTERN);
+            String entityNameLower = entityName.toLowerCase();
+
+            for (Resource resource : resources) {
+                String fileName = resource.getFilename();
+                if (fileName == null) continue;
+
+                String fileNameLower = fileName.toLowerCase();
+                String fileNameWithoutExtension = fileNameLower.endsWith(".json")
+                        ? fileNameLower.substring(0, fileNameLower.length() - 5)
+                        : fileNameLower;
+
+                String pathStr = resource.getURL().toString().toLowerCase();
+                if (fileNameWithoutExtension.equals(entityNameLower) &&
+                        (pathStr.contains("/version_" + version + "/") ||
+                         pathStr.contains("/v" + version + "/"))) {
+                    try (var inputStream = resource.getInputStream()) {
+                        return Optional.of(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.error("❌ Error searching classpath for workflow file: {}", e.getMessage(), e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Load workflow JSON from a filesystem directory.
+     * Used when {@code --workflow-dir} is specified in {@link CyodaInitConfig}.
+     */
+    private Optional<String> loadWorkflowJsonFromDir(Path workflowDir, String entityName, Integer version) {
+        Path file = findWorkflowFile(workflowDir, entityName, version);
+        if (file == null) return Optional.empty();
+        try {
+            return Optional.of(Files.readString(file));
+        } catch (IOException e) {
+            logger.error("❌ Error reading workflow file {}: {}", file, e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Find a matching workflow {@code .json} file in a filesystem directory by entity name and version.
      */
     @SuppressWarnings("SameParameterValue")
     private Path findWorkflowFile(Path workflowDir, String entityName, Integer version) {
@@ -180,12 +264,10 @@ public class CyodaInit {
                         String fileName = path.getFileName().toString().toLowerCase();
                         String entityNameLower = entityName.toLowerCase();
 
-                        // Remove .json extension from filename
                         String fileNameWithoutExtension = fileName.endsWith(".json")
                                 ? fileName.substring(0, fileName.length() - 5)
                                 : fileName;
 
-                        // Match by entity name and version directory
                         return fileNameWithoutExtension.equals(entityNameLower) &&
                                 (pathStr.contains("version_" + version) || pathStr.contains("v" + version));
                     })
@@ -201,17 +283,14 @@ public class CyodaInit {
      * Import workflow for a specific entity.
      * Supports workflow files containing either a single workflow object or an array of workflows.
      */
-    private void importWorkflowForEntity(Path workflowFile, String entityName, Integer version, String token, CyodaInitConfig initConfig) {
-        logger.info("📄 Processing workflow file for entity: {}, version: {}", entityName, version);
+    private void importWorkflowForEntity(String dtoContent, String entityName, Integer version, String token, CyodaInitConfig initConfig) {
+        logger.info("📄 Processing workflow for entity: {}, version: {}", entityName, version);
 
-
-        // Read and process workflow file
         JsonNode dtoJson;
         try {
-            String dtoContent = Files.readString(workflowFile);
             dtoJson = objectMapper.readTree(dtoContent);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to parse workflow JSON for " + entityName, e);
         }
 
         // Wrap the workflow content in the required format: {"workflows": [...]}
@@ -219,11 +298,9 @@ public class CyodaInit {
         ObjectNode wrappedContent = objectMapper.createObjectNode();
         ArrayNode workflowsArray;
         if (dtoJson.isArray()) {
-            // File contains an array of workflows - use it directly
             workflowsArray = (ArrayNode) dtoJson;
-            logger.debug("📄 Workflow file contains {} workflow(s)", workflowsArray.size());
+            logger.debug("📄 Workflow contains {} workflow(s)", workflowsArray.size());
         } else {
-            // File contains a single workflow object - wrap it in an array
             workflowsArray = objectMapper.createArrayNode();
             workflowsArray.add(dtoJson);
         }
@@ -256,7 +333,6 @@ public class CyodaInit {
 
         // Check and create entity model if needed
         checkAndCreateEntityModel(token, entityName, version, initConfig);
-
     }
 
     /**

--- a/src/main/java/com/java_template/common/tool/CyodaInitConfig.java
+++ b/src/main/java/com/java_template/common/tool/CyodaInitConfig.java
@@ -21,6 +21,18 @@ public class CyodaInitConfig {
     )
     private boolean help = false;
 
+    @Parameter(
+            names = {"--workflow-dir"},
+            description = "Absolute path to workflow directory (overrides default classpath loading)"
+    )
+    private String workflowDir = null;
+
+    @Parameter(
+            names = {"--entity-source-dir"},
+            description = "Absolute path to entity source directory (overrides default classpath scanning)"
+    )
+    private String entitySourceDir = null;
+
     /**
      * Creates a default configuration with all options set to false
      */
@@ -50,12 +62,28 @@ public class CyodaInitConfig {
         return help;
     }
 
+    public String workflowDir() {
+        return workflowDir;
+    }
+
+    public String entitySourceDir() {
+        return entitySourceDir;
+    }
+
     public void setRecreateModels(boolean recreateModels) {
         this.recreateModels = recreateModels;
     }
 
     public void setHelp(boolean help) {
         this.help = help;
+    }
+
+    public void setWorkflowDir(String workflowDir) {
+        this.workflowDir = workflowDir;
+    }
+
+    public void setEntitySourceDir(String entitySourceDir) {
+        this.entitySourceDir = entitySourceDir;
     }
 }
 

--- a/src/main/java/com/java_template/common/tool/WorkflowImportTool.java
+++ b/src/main/java/com/java_template/common/tool/WorkflowImportTool.java
@@ -1,19 +1,39 @@
 package com.java_template.common.tool;
 
 import com.beust.jcommander.JCommander;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.java_template.common.auth.Authentication;
-import com.java_template.common.config.Config;
-import com.java_template.common.util.HttpUtils;
-import com.java_template.common.util.JsonUtils;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Profile;
 
 /**
  * ABOUTME: Command-line tool for importing workflow definitions into Cyoda platform
+ * as a Spring Boot application to get full property binding and bean injection.
  */
-public class WorkflowImportTool {
+@SpringBootApplication(scanBasePackages = "com.java_template.common")
+@Profile("WorkflowImportTool")
+public class WorkflowImportTool implements CommandLineRunner {
+
+    private final CyodaInit cyodaInit;
+
+    private final Logger log = LoggerFactory.getLogger(WorkflowImportTool.class);
+
+    public WorkflowImportTool(CyodaInit cyodaInit) {
+        this.cyodaInit = cyodaInit;
+    }
+
     public static void main(String[] args) {
-        // Parse command line arguments using JCommander
+        SpringApplication app = new SpringApplication(WorkflowImportTool.class);
+        app.setWebApplicationType(WebApplicationType.NONE);
+        app.setAdditionalProfiles("WorkflowImportTool");
+        System.exit(SpringApplication.exit(app.run(args)));
+    }
+
+    @Override
+    public void run(String... args) {
         CyodaInitConfig initConfig = new CyodaInitConfig();
         JCommander jCommander = JCommander.newBuilder()
                 .addObject(initConfig)
@@ -28,26 +48,18 @@ public class WorkflowImportTool {
             System.exit(1);
         }
 
-        // Display help if requested
         if (initConfig.help()) {
             jCommander.usage();
-            System.exit(0);
+            return;
         }
 
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-        context.register(Authentication.class, HttpUtils.class, JsonUtils.class);
-        context.registerBean(ObjectMapper.class, () -> new ObjectMapper());
-        context.refresh();
-
-        Authentication auth = context.getBean(Authentication.class);
-        HttpUtils httpUtils = context.getBean(HttpUtils.class);
-        ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
-        Config config = context.getBean(Config.class);
-
-        CyodaInit init = new CyodaInit(httpUtils, auth, objectMapper,config);
-        init.initCyoda(initConfig);
-
-        context.close();
+        try {
+            cyodaInit.initCyoda(initConfig);
+        } catch (Exception e) {
+            // No other way to get the error message, so we must do the antipattern of log and throw here
+            log.error("Error importing workflows: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 }
 

--- a/src/main/java/com/java_template/common/util/HttpUtils.java
+++ b/src/main/java/com/java_template/common/util/HttpUtils.java
@@ -74,7 +74,7 @@ public class HttpUtils {
                     String responseBody = response.body();
 
                     if (statusCode >= 200 && statusCode < 300) {
-                        logger.info("[{}] {} {} succeeded", statusCode, method, url);
+                        logger.debug("[{}] {} {} succeeded", statusCode, method, url);
                     } else if (statusCode >= 300 && statusCode < 400) {
                         logger.info("[{}] {} {} redirect: {}", statusCode, method, url, responseBody);
                     } else if (statusCode >= 400 && statusCode < 500) {

--- a/src/main/java/com/java_template/common/util/SslUtils.java
+++ b/src/main/java/com/java_template/common/util/SslUtils.java
@@ -149,7 +149,7 @@ public class SslUtils {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             PermissiveTrustManager trustManager = new PermissiveTrustManager(shouldTrustAll);
-            sslContext.init(null, new TrustManager[] {trustManager}, new SecureRandom());
+            sslContext.init(null, new TrustManager[]{trustManager}, new SecureRandom());
 
             logger.info(
                     "Created permissive SSL context (trustAll={}, trustedHosts={})",
@@ -168,7 +168,7 @@ public class SslUtils {
      */
     @SuppressWarnings("unused")
     private static SSLContext createTrustAllSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
-        TrustManager[] trustAllCerts = new TrustManager[] {
+        TrustManager[] trustAllCerts = new TrustManager[]{
                 new X509TrustManager() {
                     @Override
                     public X509Certificate[] getAcceptedIssuers() {
@@ -253,7 +253,7 @@ public class SslUtils {
         try {
             NettyChannelBuilder channelBuilder;
 
-            if (config.isSslTrustAll() || shouldTrustHost(host, config)) {
+            if (!avoidSsl && (config.isSslTrustAll() || shouldTrustHost(host, config))) {
                 logger.info("Configuring gRPC channel to trust host: {} (self-signed certificates allowed)", host);
 
                 // Create an SSL context that trusts all certificates
@@ -268,14 +268,10 @@ public class SslUtils {
                         .trustManager(InsecureTrustManagerFactory.INSTANCE)
                         .build();
 
-                if (avoidSsl) {
-                    channelBuilder = NettyChannelBuilder.forAddress(host, port);
-                } else {
-                    channelBuilder = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext);
-                }
+                channelBuilder = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext);
             } else {
                 if (avoidSsl) {
-                    logger.debug("Skip using security for host: {}", host);
+                    logger.info("Skip using security for host: {}", host);
                     channelBuilder = NettyChannelBuilder.forAddress(host, port).usePlaintext();
                 } else {
                     logger.debug("Using default transport security for host: {}", host);

--- a/src/main/java/com/java_template/common/workflow/AccessRequest.java
+++ b/src/main/java/com/java_template/common/workflow/AccessRequest.java
@@ -1,0 +1,7 @@
+package com.java_template.common.workflow;
+
+// ABOUTME: Enum representing the type of access being requested on a Cyoda entity.
+// Used by EntityAccessAuthorizer to dispatch authorization decisions.
+public enum AccessRequest {
+    CREATE, READ, UPDATE, DELETE
+}

--- a/src/main/java/com/java_template/common/workflow/AllowAllEntityAccessAuthorizer.java
+++ b/src/main/java/com/java_template/common/workflow/AllowAllEntityAccessAuthorizer.java
@@ -1,0 +1,20 @@
+package com.java_template.common.workflow;
+
+// ABOUTME: Default EntityAccessAuthorizer that permits all operations unconditionally.
+// Active only when no application-supplied EntityAccessAuthorizer bean is present.
+
+import org.jetbrains.annotations.Nullable;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@ConditionalOnMissingBean(EntityAccessAuthorizer.class)
+public class AllowAllEntityAccessAuthorizer implements EntityAccessAuthorizer {
+    @Override
+    public void authorize(AccessRequest access, String entityType, int version,
+                          @Nullable UUID entityId, @Nullable String transition) {
+        // permit all by default
+    }
+}

--- a/src/main/java/com/java_template/common/workflow/EntityAccessAuthorizer.java
+++ b/src/main/java/com/java_template/common/workflow/EntityAccessAuthorizer.java
@@ -1,0 +1,23 @@
+package com.java_template.common.workflow;
+
+// ABOUTME: Framework hook for authorizing CRUD and transition access on entities at the API layer.
+// Implement this interface as a Spring bean to enforce access control on EntityCrudController.
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public interface EntityAccessAuthorizer {
+    /**
+     * Authorizes a CRUD or transition request.
+     * Throw AccessDeniedException if the current principal is not permitted.
+     *
+     * @param access     the operation type (CREATE, READ, UPDATE, DELETE)
+     * @param entityType entity type name (e.g. "Offer")
+     * @param version    entity schema version
+     * @param entityId   UUID of the target entity; null for CREATE (no entity yet)
+     * @param transition workflow transition name; non-null only for UPDATE transitions
+     */
+    void authorize(AccessRequest access, String entityType, int version,
+                   @Nullable UUID entityId, @Nullable String transition);
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+com.java_template.common.config.CyodaLightConfigCustomizer

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.java_template.common.config.SecurityConfig
+

--- a/src/main/resources/api/openapi-audit.yml
+++ b/src/main/resources/api/openapi-audit.yml
@@ -119,15 +119,15 @@ paths:
                       "items" : [ {
                         "auditEventType" : "System",
                         "severity" : "INFO",
-                        "utcTime" : "2026-02-09T18:07:58.879002Z",
-                        "microsTime" : 1770660478879002,
-                        "doneTime" : "2026-02-09T18:07:58.883Z",
+                        "utcTime" : "2026-03-16T04:52:47.825002Z",
+                        "microsTime" : 1773636767825002,
+                        "doneTime" : "2026-03-16T04:52:47.838Z",
                         "queueName" : "TRANSACTION_EXEC_1_PHASE_VERSION_CHECK",
-                        "shardId" : "4",
+                        "shardId" : "6",
                         "status" : "PROCESSED",
                         "data" : {
                           "core" : {
-                            "userId" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                            "userId" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                             "processIds" : [ {
                               "directProcessKey" : 11,
                               "type" : "DIRECT"
@@ -136,23 +136,23 @@ paths:
                             "workflowExecId" : null,
                             "workflowStackDepth" : 0,
                             "resubmitMetaInfo" : null,
-                            "submittedTransactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                            "submittedTransactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                             "entitiesCountInTransaction" : 1,
-                            "transactionConsistencyTime" : "43c81586-05e2-11f1-7f7f-7f7f7f7f7f7f",
-                            "transactionSubmitTime" : "441e72f0-05e2-11f1-903f-ae468cd3ed16",
+                            "transactionConsistencyTime" : "fa560836-20f3-11f1-7f7f-7f7f7f7f7f7f",
+                            "transactionSubmitTime" : "fa929c10-20f3-11f1-b8a5-ae468cd3ed16",
                             "parentTransactionsIds" : [ ],
                             "currentExpectedEntityVersion" : null,
                             "transEntityClassIndex" : 1190,
-                            "transEntityIdSerialized" : "DPhBYiRrEbKfj/pEP+BbsQ==",
+                            "transEntityIdSerialized" : "Iit+tjrBEbKqmhrZKARQ9g==",
                             "actionType" : "UPDATE",
                             "eventTypeIndex" : 7
                           },
                           "client" : {
-                            "traceId" : -7320170933065850375,
-                            "traceIdHigh" : 7604928849563958455
+                            "traceId" : -8073209650702103078,
+                            "traceIdHigh" : 7617711911597090194
                           }
                         },
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
                         "actor" : {
                           "id" : "00000866-0000-1000-8080-808080808080",
@@ -164,8 +164,8 @@ paths:
                         "auditEventType" : "EntityChange",
                         "changeType" : "CREATED",
                         "severity" : "INFO",
-                        "utcTime" : "2026-02-09T18:07:58.879Z",
-                        "microsTime" : 1770660478879000,
+                        "utcTime" : "2026-03-16T04:52:47.825Z",
+                        "microsTime" : 1773636767825000,
                         "changes" : {
                           "after" : {
                             "name" : "Alice",
@@ -173,38 +173,41 @@ paths:
                             "active" : false
                           }
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         }
                       }, {
                         "auditEventType" : "StateMachine",
                         "state" : "CREATED",
                         "eventType" : "FINISHED",
                         "severity" : "INFO",
-                        "utcTime" : "2026-02-09T18:07:58.869004Z",
-                        "microsTime" : 1770660478869004,
+                        "utcTime" : "2026-03-16T04:52:47.821003Z",
+                        "microsTime" : 1773636767821003,
                         "data" : {
                           "eventType" : "FINISHED",
+                          "state" : "CREATED",
                           "success" : true,
                           "stopReason" : {
                             "type" : "COMPLETED_NO_AUTO_TRANSITIONS",
                             "description" : "Workflow completed - no auto-transitions available from current state"
                           }
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         },
                         "details" : "State machine finished with result: true. Stop reason: Workflow completed - no auto-transitions available from current state"
                       }, {
@@ -212,21 +215,22 @@ paths:
                         "state" : "CREATED",
                         "eventType" : "TRANSITION_NOT_FOUND",
                         "severity" : "DEBUG",
-                        "utcTime" : "2026-02-09T18:07:58.869003Z",
-                        "microsTime" : 1770660478869003,
+                        "utcTime" : "2026-03-16T04:52:47.821002Z",
+                        "microsTime" : 1773636767821002,
                         "data" : {
                           "eventType" : "TRANSITION_NOT_FOUND",
                           "workflowName" : "Default for 'User.1'",
                           "transition" : ""
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         },
                         "details" : "State machine transition [] from state [CREATED] of workflow [Default for 'User.1'] not found"
                       }, {
@@ -234,22 +238,23 @@ paths:
                         "state" : "None",
                         "eventType" : "TRANSITION_MADE",
                         "severity" : "DEBUG",
-                        "utcTime" : "2026-02-09T18:07:58.869002Z",
-                        "microsTime" : 1770660478869002,
+                        "utcTime" : "2026-03-16T04:52:47.821001Z",
+                        "microsTime" : 1773636767821001,
                         "data" : {
                           "eventType" : "TRANSITION_MADE",
                           "workflowName" : "Default for 'User.1'",
                           "transition" : "NEW",
                           "newState" : "CREATED"
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         },
                         "details" : "Making State machine transition[NEW] of workflow[Default for 'User.1']. New state: CREATED"
                       }, {
@@ -257,22 +262,23 @@ paths:
                         "state" : "None",
                         "eventType" : "TRANSITION_MADE",
                         "severity" : "DEBUG",
-                        "utcTime" : "2026-02-09T18:07:58.869001Z",
-                        "microsTime" : 1770660478869001,
+                        "utcTime" : "2026-03-16T04:52:47.821Z",
+                        "microsTime" : 1773636767821000,
                         "data" : {
                           "eventType" : "TRANSITION_MADE",
                           "workflowName" : "Default for 'User.1'",
                           "transition" : "LOOPBACK",
                           "newState" : "None"
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         },
                         "details" : "Making State machine transition[LOOPBACK] of workflow[Default for 'User.1']. New state: None"
                       }, {
@@ -280,20 +286,21 @@ paths:
                         "state" : "None",
                         "eventType" : "WORKFLOW_FOUND",
                         "severity" : "DEBUG",
-                        "utcTime" : "2026-02-09T18:07:58.869Z",
-                        "microsTime" : 1770660478869000,
+                        "utcTime" : "2026-03-16T04:52:47.82Z",
+                        "microsTime" : 1773636767820000,
                         "data" : {
                           "eventType" : "WORKFLOW_FOUND",
                           "workflowName" : "Default for 'User.1'"
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         },
                         "details" : "State machine workflow found: Default for 'User.1'"
                       }, {
@@ -301,20 +308,21 @@ paths:
                         "state" : "None",
                         "eventType" : "STARTED",
                         "severity" : "INFO",
-                        "utcTime" : "2026-02-09T18:07:58.861001Z",
-                        "microsTime" : 1770660478861001,
+                        "utcTime" : "2026-03-16T04:52:47.817001Z",
+                        "microsTime" : 1773636767817001,
                         "data" : {
                           "eventType" : "STARTED",
                           "state" : "None"
                         },
-                        "consistencyTime" : "2026-02-09T18:07:58.312Z",
-                        "entityId" : "0cf84162-246b-11b2-9f8f-fa443fe05bb1",
+                        "consistencyTime" : "2026-03-16T04:52:47.427Z",
+                        "entityId" : "222b7eb6-3ac1-11b2-aa9a-1ad9280450f6",
                         "entityModel" : "User.1",
-                        "transactionId" : "441b65b0-05e2-11f1-903f-ae468cd3ed16",
+                        "transactionId" : "fa90ee60-20f3-11f1-b8a5-ae468cd3ed16",
                         "actor" : {
-                          "id" : "3ead796a-05e2-11f1-903f-ae468cd3ed16",
+                          "id" : "f821c32a-20f3-11f1-b8a5-ae468cd3ed16",
                           "legalId" : "TEST",
-                          "name" : "TEST_USER"
+                          "name" : "TEST_USER",
+                          "externalId" : "ext-key-TEST_USER"
                         },
                         "details" : "State machine started"
                       } ]
@@ -586,6 +594,9 @@ components:
         name:
           type: string
           description: Name of the actor
+        externalId:
+          type: string
+          description: External identifier of the actor, if applicable
       required:
         - id
         - legalId

--- a/src/main/resources/api/openapi-iam.yml
+++ b/src/main/resources/api/openapi-iam.yml
@@ -182,7 +182,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InvalidateJwtKeyPairRequest'
+              $ref: '#/components/schemas/InvalidateKeyRequest'
             examples:
               ImmediateInvalidation:
                 summary: Immediate invalidation
@@ -241,6 +241,209 @@ paths:
                       "validFrom": "2025-10-15T10:00:00.000Z",
                       "validTo": null
                     }
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /oauth/keys/trusted:
+    post:
+      summary: Register a trusted public key
+      description: |
+        Registers a pre-shared public key for JWT validation. This enables external applications
+        to sign user JWTs that Cyoda can verify without requiring a reachable OIDC discovery endpoint.
+        The key is bound to the caller's tenant (legalEntityId).
+
+        If a key with the same `keyId` already exists and belongs to the caller's tenant, it is
+        replaced atomically (upsert semantics). This makes the endpoint retry-safe during key
+        rotation — a retried request after a partial failure will succeed rather than conflict.
+        If the key belongs to a different tenant, the request is rejected with `409 Conflict`.
+
+        Use `invalidatePrevious` to retire all other active trusted keys for this tenant
+        in a single atomic operation, with an optional grace period (`invalidateGracePeriodSec`)
+        during which the old keys continue to be accepted.
+
+        Requires ADMIN or SUPER_USER role. Disabled by default — enable via
+        `cyoda.security.web.iam.trustedKeyRegistrationEnabled`.
+      operationId: registerTrustedKey
+      tags:
+        - OAuth, Keys
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterTrustedKeyRequest'
+            examples:
+              RSA256Key:
+                summary: Register an RSA-256 public key
+                value: |
+                  {
+                    "keyId": "my-app-key-1",
+                    "jwk": {
+                      "kty": "RSA",
+                      "kid": "my-app-key-1",
+                      "alg": "RS256",
+                      "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM...",
+                      "e": "AQAB"
+                    },
+                    "audience": "human",
+                    "issuers": ["https://my-app.local/"],
+                    "validTo": "2026-10-15T10:00:00.000Z"
+                  }
+      responses:
+        '200':
+          description: Trusted key registered successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrustedKeyResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          description: Feature is disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Key with this keyId belongs to a different tenant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+
+    get:
+      summary: List registered trusted keys
+      description: |
+        Returns all trusted public keys registered for the caller's tenant.
+        Requires ADMIN or SUPER_USER role.
+      operationId: listTrustedKeys
+      tags:
+        - OAuth, Keys
+      responses:
+        '200':
+          description: List of trusted keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustedKeyResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          description: Feature is disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /oauth/keys/trusted/{keyId}:
+    delete:
+      summary: Delete a trusted public key
+      description: |
+        Deletes a registered trusted public key. The key must belong to the caller's tenant.
+        Requires ADMIN or SUPER_USER role.
+      operationId: deleteTrustedKey
+      tags:
+        - OAuth, Keys
+      parameters:
+        - name: keyId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The key ID of the trusted key to delete
+      responses:
+        '200':
+          description: Trusted key deleted successfully
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /oauth/keys/trusted/{keyId}/invalidate:
+    post:
+      summary: Invalidate a trusted public key
+      description: |
+        Invalidates a registered trusted public key. After invalidation, JWTs signed with the
+        corresponding private key will no longer be accepted for validation (after the grace period).
+        Requires ADMIN or SUPER_USER role.
+      operationId: invalidateTrustedKey
+      tags:
+        - OAuth, Keys
+      parameters:
+        - name: keyId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The key ID of the trusted key to invalidate
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvalidateKeyRequest'
+      responses:
+        '200':
+          description: Trusted key invalidated successfully
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /oauth/keys/trusted/{keyId}/reactivate:
+    post:
+      summary: Reactivate a trusted public key
+      description: |
+        Reactivates a previously invalidated trusted public key, allowing JWTs signed with it to
+        be accepted again. This operation is idempotent.
+        Requires ADMIN or SUPER_USER role.
+
+        **Important**: Reactivation removes the key's expiration entirely (`validTo` is cleared to null),
+        regardless of the original `validTo` value the key was registered with. The key will remain valid
+        indefinitely until explicitly invalidated or deleted again.
+      operationId: reactivateTrustedKey
+      tags:
+        - OAuth, Keys
+      parameters:
+        - name: keyId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The key ID of the trusted key to reactivate
+      responses:
+        '200':
+          description: Trusted key reactivated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrustedKeyResponse'
         '401':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -697,6 +900,111 @@ components:
           nullable: true
           example: "2026-10-15T10:00:00.000Z"
 
+    RegisterTrustedKeyRequest:
+      type: object
+      required:
+        - keyId
+        - jwk
+        - audience
+      properties:
+        keyId:
+          type: string
+          description: Unique key identifier. Will be matched against the `kid` header in JWTs.
+          example: "my-app-key-1"
+        jwk:
+          type: object
+          additionalProperties: true
+          maxProperties: 20
+          description: |
+            A JSON Web Key (JWK) as defined in RFC 7517. Must contain the public key components only.
+            Supported key types: RSA (`kty: "RSA"`), EC (`kty: "EC"`), and OKP/EdDSA (`kty: "OKP"`).
+            See RFC 7517, RFC 7518, and RFC 8037 for field definitions.
+          example:
+            kty: "RSA"
+            kid: "my-app-key-1"
+            alg: "RS256"
+            n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM..."
+            e: "AQAB"
+        audience:
+          $ref: '#/components/schemas/KeyPairAudience'
+        issuers:
+          type: array
+          description: |
+            List of allowed issuer URIs. When this parameter is configured, the JWT must contain an iss claim,
+            and its value must match one of the entries in this list.
+          items:
+            type: string
+          example: ["https://my-app.local/"]
+        validFrom:
+          type: string
+          format: date-time
+          description: |
+            When the key becomes valid. Defaults to current time if not specified.
+          example: "2025-10-15T10:00:00.000Z"
+        validTo:
+          type: string
+          format: date-time
+          description: |
+            When the key expires. Defaults to the system-configured maximum validity.
+          example: "2026-10-15T10:00:00.000Z"
+        invalidatePrevious:
+          type: boolean
+          description: |
+            If true, invalidates all other keys for the same audience belonging to the caller's
+            tenant. Enables atomic key rotation.
+          default: false
+          example: false
+        invalidateGracePeriodSec:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            Grace period in seconds for invalidating previous keys (only used when invalidatePrevious is true).
+            Default is 0 (immediate invalidation).
+          example: 3600
+
+    TrustedKeyResponse:
+      type: object
+      required:
+        - keyId
+        - jwk
+        - audience
+        - validFrom
+        - legalEntityId
+      properties:
+        keyId:
+          type: string
+          description: Unique key identifier
+          example: "my-app-key-1"
+        jwk:
+          type: object
+          additionalProperties: true
+          maxProperties: 20
+          description: |
+            The registered public key in JWK format (RFC 7517). Contains only public key components.
+        audience:
+          $ref: '#/components/schemas/KeyPairAudience'
+        issuers:
+          type: array
+          items:
+            type: string
+          example: ["https://my-app.local/"]
+        validFrom:
+          type: string
+          format: date-time
+          description: When this key became valid
+          example: "2025-11-01T10:00:00.000Z"
+        validTo:
+          type: string
+          format: date-time
+          description: When this key expires
+          nullable: true
+          example: "2026-02-01T10:00:00.000Z"
+        legalEntityId:
+          type: string
+          description: The tenant this key is bound to
+          example: "tenant-abc-123"
+
     RegisterOidcProviderRequest:
       type: object
       required:
@@ -732,7 +1040,7 @@ components:
             type: string
           example: ["https://oidc-domain.local/", "https://oidc-domain.local/tenant1"]
 
-    InvalidateJwtKeyPairRequest:
+    InvalidateKeyRequest:
       type: object
       properties:
         gracePeriodSec:

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -45,9 +45,14 @@ paths:
     post:
       summary: Create M2M client
       description: |
-        Creates a new machine-to-machine (M2M)client for API authentication via OAuth 2.0.
+        Creates a new machine-to-machine (M2M) client for API authentication via OAuth 2.0.
 
         The created user will have M2M role permissions, necessary for getting the bearer token.
+
+        When `withAdminRole` is set to `true`, the M2M client will additionally receive the ADMIN role,
+        granting it full access to all ADMIN-level endpoints (e.g., trusted key registration).
+        This requires the `cyoda.security.web.jwt.m2m.admin-role-enabled` feature flag to be enabled;
+        otherwise, a 401 Unauthorized response is returned.
 
         **Authorization Required:** SUPER_USER role
       operationId: createTechnicalUser
@@ -55,6 +60,16 @@ paths:
         - User, Machine
       security:
         - bearerAuth: [ ]
+      parameters:
+        - name: withAdminRole
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |
+            When true, the created M2M client will additionally receive the ADMIN role.
+            Requires the M2M admin role feature flag to be enabled.
       responses:
         '200':
           description: M2M client created successfully
@@ -70,6 +85,18 @@ paths:
                     client_id: "abc523BCD"
                     client_secret: "jsdfkdfj34k5jLK#jlkj"
                     grant_type: "client_credentials"
+                    roles:
+                      - "M2M"
+                SuccessfulCreationWithAdmin:
+                  summary: Successful M2M client creation with ADMIN role
+                  description: Example response when a M2M client with ADMIN role is created
+                  value:
+                    client_id: "abc523BCD"
+                    client_secret: "jsdfkdfj34k5jLK#jlkj"
+                    grant_type: "client_credentials"
+                    roles:
+                      - "M2M"
+                      - "ADMIN"
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -234,20 +261,23 @@ paths:
     post:
       summary: Obtain access token for M2M client
       description: |
-        Authenticates a M2M client using client credentials and returns an access token.
+        Authenticates a M2M client and returns an access token.
 
-        This endpoint implements the standard OAuth 2.0 Client Credentials Grant, designed for
-        machine-to-machine authentication. The client must authenticate using HTTP Basic Authentication,
-        where the client_id and client_secret are provided in the Authorization header.
+        Supports two grant types:
 
-        The returned access token can be used to authenticate subsequent API requests using the Bearer token scheme.
+        1. **client_credentials** — Standard OAuth 2.0 Client Credentials Grant for M2M authentication.
+        2. **urn:ietf:params:oauth:grant-type:token-exchange** — RFC 8693 Token Exchange.
+           The M2M client acts on behalf of a user by presenting the user's JWT as `subject_token`.
+
+        In both cases the M2M client authenticates via HTTP Basic Authentication
+        (client_id and client_secret in the Authorization header).
 
         **Note:** This endpoint does not require an existing access token, as it serves as the authentication entry point.
       operationId: getTechnicalUserToken
       tags:
         - User, Machine
       security:
-        - basicAuth: [ ]  # Require HTTP Basic Auth      requestBody:
+        - basicAuth: [ ]  # Require HTTP Basic Auth
       # TODO: this doesn't work with kotlin-spring yet.
       #      x-spring-extra-parameters:
       #        - ServerWebExchange
@@ -260,16 +290,24 @@ paths:
           required: false   # Make it false if your OpenAPI security already marks it required
       requestBody:
         required: true
-        description: OAuth 2.0 token request using client credentials grant
+        description: >
+          OAuth 2.0 token request — either a client_credentials grant
+          or a token-exchange grant with subject_token and subject_token_type
         content:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/TokenRequest'
             examples:
               ClientCredentials:
-                summary: Token request using Basic Auth
+                summary: Client credentials grant
                 value:
                   grant_type: "client_credentials"
+              TokenExchange:
+                summary: Token exchange grant (on-behalf-of)
+                value:
+                  grant_type: "urn:ietf:params:oauth:grant-type:token-exchange"
+                  subject_token: "eyJhbGciOiJSUzI1NiIsInR..."
+                  subject_token_type: "urn:ietf:params:oauth:token-type:access_token"
       responses:
         '200':
           description: Access token issued successfully
@@ -278,13 +316,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenResponse'
               examples:
-                TokenResponse:
-                  summary: Example token response
-                  description: Successful response containing access token
+                ClientCredentialsResponse:
+                  summary: Client credentials token response
                   value:
                     access_token: "eyJhbGciOiJIUzI1NiIsInR..."
                     token_type: "Bearer"
                     expires_in: 3600
+                TokenExchangeResponse:
+                  summary: Token exchange response
+                  value:
+                    access_token: "eyJhbGciOiJSUzI1NiIsInR..."
+                    token_type: "Bearer"
+                    expires_in: 3600
+                    issued_token_type: "urn:ietf:params:oauth:token-type:access_token"
         '400':
           description: Bad request - Invalid credentials or malformed request
           content:
@@ -296,14 +340,14 @@ paths:
                   summary: Invalid grant type
                   value:
                     error: "unsupported_grant_type"
-                    error_description: "Grant type must be 'client_credentials'"
-                MissingCredentials:
-                  summary: Missing client credentials
+                    error_description: "Grant type must be 'client_credentials' or 'urn:ietf:params:oauth:grant-type:token-exchange'"
+                MissingSubjectToken:
+                  summary: Missing subject_token for token-exchange
                   value:
                     error: "invalid_request"
-                    error_description: "Missing client_id or client_secret"
+                    error_description: "subject_token is required for token-exchange grant"
         '401':
-          description: Unauthorized - Invalid client credentials
+          description: Unauthorized - Invalid client credentials or subject token
           content:
             application/json:
               schema:
@@ -314,6 +358,23 @@ paths:
                   value:
                     error: "invalid_client"
                     error_description: "Client authentication failed"
+                InvalidSubjectToken:
+                  summary: Invalid or expired subject token
+                  value:
+                    error: "invalid_grant"
+                    error_description: "Subject token validation failed"
+        '403':
+          description: Forbidden - Tenant boundary violation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                TenantMismatch:
+                  summary: Tenant mismatch between M2M client and subject user
+                  value:
+                    error: "access_denied"
+                    error_description: "Tenant boundary violation — M2M client and subject user belong to different tenants"
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -556,6 +617,7 @@ components:
             - unauthorized_client
             - unsupported_grant_type
             - invalid_scope
+            - access_denied
           example: "invalid_request"
         error_description:
           type: string
@@ -592,10 +654,33 @@ components:
           enum:
             - client_credentials
           example: "client_credentials"
+        client_id_issued_at:
+          type: integer
+          format: int64
+          description: |
+            Time at which the client identifier was issued, as the number of seconds
+            from 1970-01-01T00:00:00Z (Unix epoch) per RFC 7591 Section 3.2.1.
+          example: 1709913600
+        client_secret_expires_at:
+          type: integer
+          format: int64
+          description: |
+            Time at which the client secret will expire, as the number of seconds
+            from 1970-01-01T00:00:00Z (Unix epoch), or 0 if it will not expire.
+            Per RFC 7591 Section 3.2.1, this field is required when a client_secret is issued.
+          example: 0
+        roles:
+          type: array
+          items:
+            type: string
+          description: The roles assigned to the M2M client
+          example: ["M2M"]
       required:
         - client_id
         - client_secret
         - grant_type
+        - client_secret_expires_at
+        - roles
 
     TechnicalUser:
       type: object
@@ -618,22 +703,66 @@ components:
           format: date-time
           description: The date and time when the M2M client was last updated
           example: "2023-04-21T10:02:27.88Z"
+        roles:
+          type: array
+          items:
+            type: string
+          description: The roles assigned to the M2M client
+          example: ["M2M"]
       required:
         - clientId
         - creationDate
         - lastUpdateDate
+        - roles
 
     TokenRequest:
+      description: >
+        OAuth 2.0 token request. Must be one of the supported grant types:
+        client_credentials (RFC 6749) or token-exchange (RFC 8693).
+      oneOf:
+        - $ref: '#/components/schemas/ClientCredentialsTokenRequest'
+        - $ref: '#/components/schemas/TokenExchangeTokenRequest'
+      discriminator:
+        propertyName: grant_type
+        mapping:
+          client_credentials: '#/components/schemas/ClientCredentialsTokenRequest'
+          "urn:ietf:params:oauth:grant-type:token-exchange": '#/components/schemas/TokenExchangeTokenRequest'
+
+    ClientCredentialsTokenRequest:
       type: object
-      description: OAuth 2.0 token request for client credentials grant
+      description: OAuth 2.0 client_credentials grant request (RFC 6749).
+        The client authenticates via Basic Auth; no additional fields are required.
       properties:
         grant_type:
           type: string
           enum: [ client_credentials ]
-          description: Must be 'client_credentials'
-          example: "client_credentials"
+          x-enum-varnames: [ client_credentials ]
+          description: The OAuth 2.0 grant type
       required:
         - grant_type
+
+    TokenExchangeTokenRequest:
+      type: object
+      description: OAuth 2.0 token-exchange grant request (RFC 8693).
+        Exchanges a subject token for a new access token on behalf of the subject.
+      properties:
+        grant_type:
+          type: string
+          enum: [ "urn:ietf:params:oauth:grant-type:token-exchange" ]
+          x-enum-varnames: [ token_exchange ]
+          description: The OAuth 2.0 grant type
+        subject_token:
+          type: string
+          description: The subject token to exchange
+        subject_token_type:
+          type: string
+          enum: [ "urn:ietf:params:oauth:token-type:jwt", "urn:ietf:params:oauth:token-type:access_token" ]
+          x-enum-varnames: [ jwt, access_token ]
+          description: The type of the subject token
+      required:
+        - grant_type
+        - subject_token
+        - subject_token_type
 
     TokenResponse:
       type: object
@@ -667,6 +796,11 @@ components:
           description: The scope of the access token, as per RFC 6749 Section 3.3.
             See https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
           example: "ROLE_M2M"
+        issued_token_type:
+          type: string
+          description: The type of the issued token (present only for token-exchange responses, per RFC 8693)
+          enum: [ "urn:ietf:params:oauth:token-type:access_token" ]
+          x-enum-varnames: [ access_token ]
       required:
         - access_token
         - token_type

--- a/src/main/resources/schema/common/EntityMetadata.json
+++ b/src/main/resources/schema/common/EntityMetadata.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cyoda.com/cloud/event/search/EntityMetadata.json",
+  "$id": "https://cyoda.com/cloud/event/common/EntityMetadata.json",
   "title": "EntityMetadata",
   "description": "Metadata about an entity. id, modelKey and creationDate are invariant against the point-in-time. All other values are with respect to the as-at point-in-time for which the entity was retrieved. If the point-in-time was not explicitly set, the values correspond to the latest state of the entity.",
   "type": "object",

--- a/src/main/resources/schema/model/EntityModelExportResponse.json
+++ b/src/main/resources/schema/model/EntityModelExportResponse.json
@@ -23,8 +23,8 @@
     }
   },
   "required": [
+    "modelId",
     "model",
-    "modelVersion",
     "payload"
   ]
 }

--- a/src/main/resources/schema/search/EntitySnapshotSearchResponse.json
+++ b/src/main/resources/schema/search/EntitySnapshotSearchResponse.json
@@ -13,7 +13,6 @@
     }
   },
   "required": [
-    "model",
-    "condition"
+    "status"
   ]
 }

--- a/src/test/java/com/example/application/criterion/ExampleEntityCriterion.java
+++ b/src/test/java/com/example/application/criterion/ExampleEntityCriterion.java
@@ -49,7 +49,6 @@ public class ExampleEntityCriterion implements CyodaCriterion {
 
         return serializer.withRequest(request)
             .evaluateEntity(ExampleEntity.class, this::validateEntity)
-            .withReasonAttachment(ReasonAttachmentStrategy.toWarnings())
             .complete();
     }
 

--- a/src/test/java/com/example/application/entity/example_entity/version_1/ExampleEntity.java
+++ b/src/test/java/com/example/application/entity/example_entity/version_1/ExampleEntity.java
@@ -20,7 +20,7 @@ import java.util.List;
  * - Lombok @Data usage
 
  * To create a new entity:
- * 1. Copy this file to your entity package (e.g., com.java_template.application.entity.yourname.version_1)
+ * 1. Copy this file to your entity package (e.g., com.riskblocs.application.entity.yourname.version_1)
  * 2. Rename class from ExampleEntity to YourEntityName
  * 3. Update ENTITY_NAME constant
  * 4. Modify fields according to your business requirements

--- a/src/test/java/com/example/tests/ExampleEntityCriterionTest.java
+++ b/src/test/java/com/example/tests/ExampleEntityCriterionTest.java
@@ -125,9 +125,8 @@ class ExampleEntityCriterionTest {
         assertNotNull(response);
         assertTrue(response.getSuccess()); // Evaluation succeeded
         assertFalse(response.getMatches()); // But entity doesn't match criteria
-        assertNotNull(response.getWarnings());
-        assertFalse(response.getWarnings().isEmpty());
-        assertTrue(response.getWarnings().getFirst().contains("Entity is not valid"));
+        assertNotNull(response.getReason());
+        assertTrue(response.getReason().contains("Entity is not valid"));
     }
 
     @Test

--- a/src/test/java/com/example/tests/ExampleEntityProcessorTest.java
+++ b/src/test/java/com/example/tests/ExampleEntityProcessorTest.java
@@ -327,7 +327,7 @@ class ExampleEntityProcessorTest {
 
         // Create metadata with technical ID
         ObjectNode metadataJson = objectMapper.createObjectNode();
-        metadataJson.put("id", UUID.randomUUID().toString());
+        metadataJson.put("id", java.util.UUID.randomUUID().toString());
         metadataJson.put("state", "DRAFT");
 
         // Create payload with entity data and metadata

--- a/src/test/java/com/java_template/common/auth/AesGcmEncryptionTest.java
+++ b/src/test/java/com/java_template/common/auth/AesGcmEncryptionTest.java
@@ -1,0 +1,55 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Unit tests for AesGcmEncryption encrypt/decrypt round-trip and error cases.
+
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AesGcmEncryptionTest {
+
+    @Test
+    void encryptAndDecrypt_roundTrip() {
+        SecretKey key = AesGcmEncryption.decodeKey(Base64.getEncoder().encodeToString(new byte[32]));
+        byte[] plaintext = "test-private-key-bytes".getBytes();
+
+        String encrypted = AesGcmEncryption.encrypt(plaintext, key);
+        byte[] decrypted = AesGcmEncryption.decrypt(encrypted, key);
+
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    @Test
+    void encrypt_producesDifferentCiphertextsForSamePlaintext() {
+        SecretKey key = AesGcmEncryption.decodeKey(Base64.getEncoder().encodeToString(new byte[32]));
+        byte[] plaintext = "same-input".getBytes();
+
+        String enc1 = AesGcmEncryption.encrypt(plaintext, key);
+        String enc2 = AesGcmEncryption.encrypt(plaintext, key);
+
+        assertThat(enc1).isNotEqualTo(enc2);
+    }
+
+    @Test
+    void decrypt_throwsOboTokenException_onWrongKey() {
+        SecretKey key1 = AesGcmEncryption.decodeKey(Base64.getEncoder().encodeToString(new byte[32]));
+        byte[] keyBytes = new byte[32];
+        keyBytes[0] = 1;
+        SecretKey key2 = AesGcmEncryption.decodeKey(Base64.getEncoder().encodeToString(keyBytes));
+
+        String encrypted = AesGcmEncryption.encrypt("secret".getBytes(), key1);
+
+        assertThatThrownBy(() -> AesGcmEncryption.decrypt(encrypted, key2))
+                .isInstanceOf(OboTokenException.class);
+    }
+
+    @Test
+    void decodeKey_throwsOboTokenException_onInvalidBase64() {
+        assertThatThrownBy(() -> AesGcmEncryption.decodeKey("not-valid-base64!!!"))
+                .isInstanceOf(OboTokenException.class);
+    }
+}

--- a/src/test/java/com/java_template/common/auth/AuthClaimsParserTest.java
+++ b/src/test/java/com/java_template/common/auth/AuthClaimsParserTest.java
@@ -1,0 +1,58 @@
+package com.java_template.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthClaimsParserTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void parseRoles_returnsRoles_whenValidJson() {
+        String json = "{\"legalEntityId\":\"org-1\",\"roles\":[\"USER\",\"ADMIN\"]}";
+        assertThat(AuthClaimsParser.parseRoles(objectMapper, json)).containsExactly("USER", "ADMIN");
+    }
+
+    @Test
+    void parseRoles_returnsEmpty_whenRolesFieldAbsent() {
+        String json = "{\"legalEntityId\":\"org-1\"}";
+        assertThat(AuthClaimsParser.parseRoles(objectMapper, json)).isEmpty();
+    }
+
+    @Test
+    void parseRoles_returnsEmpty_whenInputNull() {
+        assertThat(AuthClaimsParser.parseRoles(objectMapper, null)).isEmpty();
+    }
+
+    @Test
+    void parseRoles_returnsEmpty_whenInputBlank() {
+        assertThat(AuthClaimsParser.parseRoles(objectMapper, "   ")).isEmpty();
+    }
+
+    @Test
+    void parseRoles_returnsEmpty_whenMalformedJson() {
+        assertThat(AuthClaimsParser.parseRoles(objectMapper, "not-json")).isEmpty();
+    }
+
+    @Test
+    void parseRoles_returnsEmpty_whenRolesIsNotList() {
+        String json = "{\"roles\":\"single-string\"}";
+        assertThat(AuthClaimsParser.parseRoles(objectMapper, json)).isEmpty();
+    }
+
+    @Test
+    void parseRoles_convertsElementsToString() {
+        String json = "{\"roles\":[\"USER\"]}";
+        List<String> roles = AuthClaimsParser.parseRoles(objectMapper, json);
+        assertThat(roles).containsExactly("USER");
+    }
+
+    @Test
+    void authContextExtensionRolesKey_isRoles() {
+        assertThat(AuthClaimsParser.AUTH_CONTEXT_EXTENSION_ROLES_KEY).isEqualTo("roles");
+    }
+}

--- a/src/test/java/com/java_template/common/auth/CloudEventAuthContextExtractorTest.java
+++ b/src/test/java/com/java_template/common/auth/CloudEventAuthContextExtractorTest.java
@@ -1,0 +1,80 @@
+package com.java_template.common.auth;
+
+import io.cloudevents.v1.proto.CloudEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudEventAuthContextExtractorTest {
+
+    private CloudEventAuthContextExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new CloudEventAuthContextExtractor();
+    }
+
+    @Test
+    void extract_returnsEmpty_whenNoAuthTypeAttribute() {
+        CloudEvent event = CloudEvent.newBuilder().build();
+        assertThat(extractor.extract(event)).isEmpty();
+    }
+
+    @Test
+    void extract_returnsContext_whenAuthTypePresent() {
+        CloudEvent event = cloudEvent("user", "uuid-1", "{\"roles\":[\"USER\"]}");
+        Optional<CloudEventAuthContext> result = extractor.extract(event);
+        assertThat(result).isPresent();
+        assertThat(result.get().authType()).isEqualTo("user");
+        assertThat(result.get().authId()).isEqualTo("uuid-1");
+        assertThat(result.get().authClaimsJson()).isEqualTo("{\"roles\":[\"USER\"]}");
+    }
+
+    @Test
+    void extract_returnsContext_withNullAuthId_whenAuthIdAbsent() {
+        CloudEvent event = CloudEvent.newBuilder()
+                .putAttributes("authtype", strAttr("service_account"))
+                .build();
+        Optional<CloudEventAuthContext> result = extractor.extract(event);
+        assertThat(result).isPresent();
+        assertThat(result.get().authType()).isEqualTo("service_account");
+        assertThat(result.get().authId()).isNull();
+        assertThat(result.get().authClaimsJson()).isNull();
+    }
+
+    @Test
+    void extract_handlesAllAuthTypeValues() {
+        for (String authType : new String[]{"user", "service_account", "system", "unauthenticated", "unknown"}) {
+            CloudEvent event = CloudEvent.newBuilder()
+                    .putAttributes("authtype", strAttr(authType))
+                    .build();
+            Optional<CloudEventAuthContext> result = extractor.extract(event);
+            assertThat(result).isPresent();
+            assertThat(result.get().authType()).isEqualTo(authType);
+        }
+    }
+
+    @Test
+    void isUserContext_trueOnlyForUser() {
+        assertThat(new CloudEventAuthContext("user", null, null).isUserContext()).isTrue();
+        assertThat(new CloudEventAuthContext("service_account", null, null).isUserContext()).isFalse();
+        assertThat(new CloudEventAuthContext("system", null, null).isUserContext()).isFalse();
+        assertThat(new CloudEventAuthContext("unauthenticated", null, null).isUserContext()).isFalse();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private CloudEvent cloudEvent(String authType, String authId, String authClaims) {
+        return CloudEvent.newBuilder()
+                .putAttributes("authtype",   strAttr(authType))
+                .putAttributes("authid",     strAttr(authId))
+                .putAttributes("authclaims", strAttr(authClaims))
+                .build();
+    }
+
+    private CloudEvent.CloudEventAttributeValue strAttr(String value) {
+        return CloudEvent.CloudEventAttributeValue.newBuilder().setCeString(value).build();
+    }
+}

--- a/src/test/java/com/java_template/common/auth/DefaultEventUserResolverTest.java
+++ b/src/test/java/com/java_template/common/auth/DefaultEventUserResolverTest.java
@@ -1,0 +1,49 @@
+package com.java_template.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DefaultEventUserResolverTest {
+
+    private DefaultEventUserResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new DefaultEventUserResolver(new ObjectMapper());
+    }
+
+    @Test
+    void resolve_returnsIdentity_whenAuthIdAndClaimsPresent() {
+        CloudEventAuthContext ctx = new CloudEventAuthContext("user", "user-uuid-1", "{\"roles\":[\"USER\"]}");
+        EventUserIdentity identity = resolver.resolve(ctx);
+        assertThat(identity.userId()).isEqualTo("user-uuid-1");
+        assertThat(identity.roles()).containsExactly("USER");
+    }
+
+    @Test
+    void resolve_returnsEmptyRoles_whenAuthClaimsNull() {
+        CloudEventAuthContext ctx = new CloudEventAuthContext("user", "user-uuid-1", null);
+        EventUserIdentity identity = resolver.resolve(ctx);
+        assertThat(identity.userId()).isEqualTo("user-uuid-1");
+        assertThat(identity.roles()).isEmpty();
+    }
+
+    @Test
+    void resolve_throws_whenAuthIdNull() {
+        CloudEventAuthContext ctx = new CloudEventAuthContext("user", null, null);
+        assertThatThrownBy(() -> resolver.resolve(ctx))
+                .isInstanceOf(EventUserResolutionException.class)
+                .hasMessageContaining("authid");
+    }
+
+    @Test
+    void resolve_throws_whenAuthIdBlank() {
+        CloudEventAuthContext ctx = new CloudEventAuthContext("user", "  ", null);
+        assertThatThrownBy(() -> resolver.resolve(ctx))
+                .isInstanceOf(EventUserResolutionException.class);
+    }
+}

--- a/src/test/java/com/java_template/common/auth/EventAuthContextHandlerTest.java
+++ b/src/test/java/com/java_template/common/auth/EventAuthContextHandlerTest.java
@@ -1,0 +1,190 @@
+package com.java_template.common.auth;
+
+import io.cloudevents.v1.proto.CloudEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventAuthContextHandlerTest {
+
+    @Mock
+    private EventUserResolver userResolver;
+
+    private OboProperties oboProperties;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @BeforeEach
+    void setUp() {
+        oboProperties = new OboProperties();
+        oboProperties.setRolesClaimName("roles");
+    }
+
+    private EventAuthContextHandler handler(AuthContextMode mode) {
+        EventAuthContextProperties props = new EventAuthContextProperties();
+        props.setMode(mode);
+        CloudEventAuthContextExtractor extractor = new CloudEventAuthContextExtractor();
+        return new EventAuthContextHandler(props, extractor, userResolver, oboProperties);
+    }
+
+    // ── IGNORE mode ──────────────────────────────────────────────────────────
+
+    @Test
+    void establish_ignoreMode_clearsContextAndReturnsScope_withoutCallingResolver() {
+        EventAuthContextHandler h = handler(AuthContextMode.IGNORE);
+        CloudEvent event = userEvent("uuid-1", "{\"roles\":[\"USER\"]}");
+
+        try (EventAuthContextScope scope = h.establish(event)) {
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+        verifyNoInteractions(userResolver);
+    }
+
+    // ── REQUIRED mode — auth context absent ──────────────────────────────────
+
+    @Test
+    void establish_requiredMode_throwsMissing_whenNoAuthContext() {
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = CloudEvent.newBuilder().build();
+
+        assertThatThrownBy(() -> h.establish(event))
+                .isInstanceOf(EventAuthContextMissingException.class)
+                .hasMessageContaining("REQUIRED");
+    }
+
+    // ── OPTIONAL mode — auth context absent ──────────────────────────────────
+
+    @Test
+    void establish_optionalMode_clearsContext_whenNoAuthContext() {
+        EventAuthContextHandler h = handler(AuthContextMode.OPTIONAL);
+        CloudEvent event = CloudEvent.newBuilder().build();
+
+        try (EventAuthContextScope scope = h.establish(event)) {
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+        verifyNoInteractions(userResolver);
+    }
+
+    // ── authtype = user ───────────────────────────────────────────────────────
+
+    @Test
+    void establish_switchesContext_whenAuthTypeUser() {
+        when(userResolver.resolve(any())).thenReturn(new EventUserIdentity("uuid-1", List.of("USER")));
+
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = userEvent("uuid-1", "{\"roles\":[\"USER\"]}");
+
+        try (EventAuthContextScope scope = h.establish(event)) {
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(auth).isInstanceOf(JwtAuthenticationToken.class);
+            JwtAuthenticationToken jwt = (JwtAuthenticationToken) auth;
+            assertThat(jwt.getToken().getSubject()).isEqualTo("uuid-1");
+            assertThat(jwt.getToken().getClaimAsStringList("roles")).containsExactly("USER");
+        }
+    }
+
+    @Test
+    void establish_restoresContext_onScopeClose() {
+        when(userResolver.resolve(any())).thenReturn(new EventUserIdentity("uuid-1", List.of()));
+
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = userEvent("uuid-1", null);
+
+        try (EventAuthContextScope ignored = h.establish(event)) {
+            // inside scope — context is set
+        }
+        // after close — context restored to empty
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void establish_propagatesResolverException() {
+        when(userResolver.resolve(any())).thenThrow(new EventUserResolutionException("not found"));
+
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = userEvent("uuid-1", null);
+
+        assertThatThrownBy(() -> h.establish(event))
+                .isInstanceOf(EventUserResolutionException.class)
+                .hasMessageContaining("not found");
+    }
+
+    // ── authtype != user ──────────────────────────────────────────────────────
+
+    @Test
+    void establish_clearsContext_whenAuthTypeServiceAccount() {
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = nonUserEvent("service_account");
+
+        try (EventAuthContextScope scope = h.establish(event)) {
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+        verifyNoInteractions(userResolver);
+    }
+
+    @Test
+    void establish_clearsContext_whenAuthTypeSystem() {
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = nonUserEvent("system");
+
+        try (EventAuthContextScope scope = h.establish(event)) {
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+
+    // ── synthetic JWT uses configured roles claim name ────────────────────────
+
+    @Test
+    void establish_usesConfiguredRolesClaimName_inSyntheticJwt() {
+        oboProperties.setRolesClaimName("user_roles");
+        when(userResolver.resolve(any())).thenReturn(new EventUserIdentity("uuid-1", List.of("ADMIN")));
+
+        EventAuthContextHandler h = handler(AuthContextMode.REQUIRED);
+        CloudEvent event = userEvent("uuid-1", null);
+
+        try (EventAuthContextScope scope = h.establish(event)) {
+            JwtAuthenticationToken jwt = (JwtAuthenticationToken)
+                    SecurityContextHolder.getContext().getAuthentication();
+            assertThat(jwt.getToken().getClaimAsStringList("user_roles")).containsExactly("ADMIN");
+            assertThat(jwt.getToken().hasClaim("roles")).isFalse();
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private CloudEvent userEvent(String authId, String authClaims) {
+        CloudEvent.Builder b = CloudEvent.newBuilder()
+                .putAttributes("authtype", strAttr("user"))
+                .putAttributes("authid",   strAttr(authId));
+        if (authClaims != null) {
+            b.putAttributes("authclaims", strAttr(authClaims));
+        }
+        return b.build();
+    }
+
+    private CloudEvent nonUserEvent(String authType) {
+        return CloudEvent.newBuilder()
+                .putAttributes("authtype", strAttr(authType))
+                .build();
+    }
+
+    private CloudEvent.CloudEventAttributeValue strAttr(String value) {
+        return CloudEvent.CloudEventAttributeValue.newBuilder().setCeString(value).build();
+    }
+}

--- a/src/test/java/com/java_template/common/auth/OboAwareAuthenticationTest.java
+++ b/src/test/java/com/java_template/common/auth/OboAwareAuthenticationTest.java
@@ -1,0 +1,162 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Unit tests for OboAwareAuthentication OBO/M2M dispatch logic.
+
+import com.java_template.common.config.Config;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OboAwareAuthenticationTest {
+
+    @Mock
+    private OboTokenService oboTokenService;
+
+    @Mock
+    private Config config;
+
+    private OboProperties enabledProps;
+    private TestOboAwareAuthentication subject;
+
+    @BeforeEach
+    void setUp() {
+        // Stub config methods needed by the Authentication superclass constructor
+        when(config.getCyodaApiUrl()).thenReturn("http://cyoda.example.com/api");
+        when(config.getCyodaClientId()).thenReturn("test-client");
+        when(config.getCyodaClientSecret()).thenReturn("test-secret");
+        when(config.getTrustedHosts()).thenReturn(List.of());
+
+        enabledProps = new OboProperties();
+        enabledProps.setEncryptionKey("dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleTA=");
+        enabledProps.setRolesClaimName("roles");
+
+        subject = new TestOboAwareAuthentication(config, enabledProps, oboTokenService);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getAccessToken_returnsOboToken_whenUserJwtInContext() {
+        setSecurityContext("user-1", List.of("ROLE_INVESTOR"));
+        OAuth2AccessToken oboToken = fakeToken("obo-token");
+        when(oboTokenService.getOboToken("user-1", List.of("INVESTOR")))
+                .thenReturn(Optional.of(oboToken));
+
+        assertThat(subject.getAccessToken().getTokenValue()).isEqualTo("obo-token");
+    }
+
+    @Test
+    void getAccessToken_throwsOboTokenException_whenOboNotConfigured() {
+        OboProperties disabledProps = new OboProperties(); // blank encryption-key
+        TestOboAwareAuthentication disabledSubject =
+                new TestOboAwareAuthentication(config, disabledProps, oboTokenService);
+
+        setSecurityContext("user-1", List.of("ROLE_INVESTOR"));
+
+        assertThatThrownBy(disabledSubject::getAccessToken)
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("not configured");
+    }
+
+    @Test
+    void getAccessToken_throwsOboTokenException_whenExchangeFails() {
+        setSecurityContext("user-1", List.of("ROLE_INVESTOR"));
+        when(oboTokenService.getOboToken(any(), any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(subject::getAccessToken)
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("user-1");
+    }
+
+    @Test
+    void getAccessToken_returnsM2mToken_whenNoUserContext() {
+        SecurityContextHolder.clearContext();
+        assertThat(subject.getAccessToken().getTokenValue()).isEqualTo("m2m-token");
+        verifyNoInteractions(oboTokenService);
+    }
+
+    @Test
+    void stripRolePrefix_appliedBeforePassingToOboService() {
+        setSecurityContext("user-1", List.of("ROLE_INVESTOR", "ADMIN"));
+        when(oboTokenService.getOboToken("user-1", List.of("INVESTOR", "ADMIN")))
+                .thenReturn(Optional.of(fakeToken("obo")));
+
+        subject.getAccessToken();
+
+        verify(oboTokenService).getOboToken("user-1", List.of("INVESTOR", "ADMIN"));
+    }
+
+    @Test
+    void getAccessToken_throwsOboTokenException_whenJwtHasNoSub() {
+        Jwt jwt = Jwt.withTokenValue("tok")
+                .header("alg", "HS256")
+                .claim("roles", List.of("ROLE_INVESTOR"))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+
+        assertThatThrownBy(subject::getAccessToken)
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("sub");
+    }
+
+    private void setSecurityContext(String sub, List<String> roles) {
+        Jwt jwt = Jwt.withTokenValue("tok")
+                .header("alg", "HS256")
+                .subject(sub)
+                .claim("roles", roles)
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+    }
+
+    private static OAuth2AccessToken fakeToken(String value) {
+        return new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, value,
+                Instant.now(), Instant.now().plusSeconds(3600));
+    }
+
+    // Test subclass: overrides getAccessToken() to bypass actual OAuth2 M2M infrastructure,
+    // while delegating the OBO path to super (OboAwareAuthentication) which is what we're testing.
+    private static class TestOboAwareAuthentication extends OboAwareAuthentication {
+
+        TestOboAwareAuthentication(Config config, OboProperties props, OboTokenService oboTokenService) {
+            super(config, props, oboTokenService);
+        }
+
+        @Override
+        public OAuth2AccessToken getAccessToken() {
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth instanceof JwtAuthenticationToken) {
+                // Delegate OBO path to parent (the code under test)
+                return super.getAccessToken();
+            }
+            // Return fake M2M token without calling real OAuth2 client infrastructure
+            return new OAuth2AccessToken(
+                    OAuth2AccessToken.TokenType.BEARER, "m2m-token",
+                    Instant.now(), Instant.now().plusSeconds(3600));
+        }
+    }
+}

--- a/src/test/java/com/java_template/common/auth/OboKeyRegistrationServiceTest.java
+++ b/src/test/java/com/java_template/common/auth/OboKeyRegistrationServiceTest.java
@@ -1,0 +1,191 @@
+package com.java_template.common.auth;
+
+import com.java_template.common.config.Config;
+import com.java_template.common.dto.PageResult;
+import com.java_template.common.service.EntityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ABOUTME: Verifies the trusted-key registration request body matches the Cyoda API schema
+ * (JWK format, audience field, validTo absolute timestamp) and error handling for 409 conflicts.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OboKeyRegistrationServiceTest {
+
+    @Mock private Authentication authentication;
+    @Mock private EntityService entityService;
+    @Mock private Config config;
+
+    private OboKeyRegistrationService service;
+    private final AtomicReference<Map<String, Object>> capturedTrustedKeyBody = new AtomicReference<>();
+    private boolean trustedKeyPostShouldThrow409 = false;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        trustedKeyPostShouldThrow409 = false;
+        capturedTrustedKeyBody.set(null);
+
+        OboProperties oboProperties = new OboProperties();
+        oboProperties.setEncryptionKey("BO1DMziwLVFBy+eBH4KSewhkCaPpP+2XTw018eTacho=");
+        oboProperties.setAdminClientId("admin-id");
+        oboProperties.setAdminClientSecret("admin-secret");
+        oboProperties.setKeyId("test-key-001");
+        oboProperties.setIssuer("test-issuer");
+        oboProperties.setValidityDays(90);
+
+        when(config.getCyodaApiUrl()).thenReturn("http://cyoda.test/api");
+        lenient().when(config.getCyodaClientId()).thenReturn("client-id");
+        lenient().when(config.getCyodaClientSecret()).thenReturn("client-secret");
+        lenient().when(config.getTrustedHosts()).thenReturn(List.of());
+
+        OAuth2AccessToken token = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, "m2m-token",
+                Instant.now(), Instant.now().plusSeconds(3600));
+        when(authentication.getAccessToken()).thenReturn(token);
+
+        when(entityService.findAll(any(), any())).thenReturn(PageResult.of(null, List.of(), 0, 100, 0));
+        lenient().when(entityService.create(any())).thenReturn(null);
+
+        SubjectTokenSigner signer = new SubjectTokenSigner(oboProperties);
+        service = new OboKeyRegistrationService(oboProperties, signer, authentication, entityService, config);
+
+        RestClient mockRestClient = buildDispatchingRestClient();
+        Field restClientField = OboKeyRegistrationService.class.getDeclaredField("restClient");
+        restClientField.setAccessible(true);
+        restClientField.set(service, mockRestClient);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void registerPublicKey_sendsJwkFormatBody() {
+        service.onStartup();
+
+        Map<String, Object> body = capturedTrustedKeyBody.get();
+        assertThat(body).as("Body sent to POST /oauth/keys/trusted should have been captured").isNotNull();
+        assertThat(body.get("keyId")).isEqualTo("test-key-001");
+
+        assertThat(body.get("jwk")).isInstanceOf(Map.class);
+        Map<String, Object> jwk = (Map<String, Object>) body.get("jwk");
+        assertThat(jwk.get("kty")).isEqualTo("RSA");
+        assertThat(jwk.get("kid")).isEqualTo("test-key-001");
+        assertThat(jwk.get("alg")).isEqualTo("RS256");
+        assertThat(jwk).containsKeys("n", "e");
+
+        assertThat(body.get("audience")).isEqualTo("human");
+        assertThat((String) body.get("validTo")).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*Z");
+        assertThat(body.get("issuers")).isEqualTo(List.of("test-issuer"));
+
+        assertThat(body).doesNotContainKeys("algorithm", "publicKey", "providerId", "validityDays");
+    }
+
+    @Test
+    void registerPublicKey_409conflict_throwsWithDiagnostic() {
+        trustedKeyPostShouldThrow409 = true;
+
+        // onStartup catches OboTokenException internally and logs it.
+        // The body is captured before retrieve() throws 409.
+        // Verify that no entity was created (create is called only after successful registration).
+        service.onStartup();
+
+        verify(entityService, never()).create(any());
+    }
+
+    @SuppressWarnings("rawtypes")
+    private RestClient buildDispatchingRestClient() {
+        RestClient restClient = mock(RestClient.class);
+
+        // GET dispatcher: /account and /model/export
+        when(restClient.get()).thenAnswer(inv -> {
+            RestClient.RequestHeadersUriSpec getSpec = mock(RestClient.RequestHeadersUriSpec.class);
+            org.mockito.stubbing.Answer<Object> getUriAnswer = uriInv -> {
+                String uri = uriInv.getArgument(0);
+                RestClient.RequestHeadersSpec headersSpec = mock(RestClient.RequestHeadersSpec.class);
+                when(headersSpec.header(anyString(), anyString())).thenReturn(headersSpec);
+                RestClient.ResponseSpec respSpec = mock(RestClient.ResponseSpec.class);
+                when(headersSpec.retrieve()).thenReturn(respSpec);
+
+                if (uri.contains("/account")) {
+                    when(respSpec.body(eq(Map.class))).thenReturn(
+                            Map.of("userAccountInfo", Map.of("legalEntity", Map.of("id", "test-org-id"))));
+                } else if (uri.contains("/model/export")) {
+                    when(respSpec.toBodilessEntity()).thenReturn(ResponseEntity.ok().build());
+                }
+                return headersSpec;
+            };
+            when(getSpec.uri(anyString())).thenAnswer(getUriAnswer);
+            when(getSpec.uri(anyString(), any(Object[].class))).thenAnswer(getUriAnswer);
+            return getSpec;
+        });
+
+        // POST dispatcher: /oauth/token and /oauth/keys/trusted
+        when(restClient.post()).thenAnswer(inv -> {
+            RestClient.RequestBodyUriSpec postSpec = mock(RestClient.RequestBodyUriSpec.class);
+            org.mockito.stubbing.Answer<Object> postUriAnswer = uriInv -> {
+                String uri = uriInv.getArgument(0);
+                RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
+                when(bodySpec.header(anyString(), anyString())).thenReturn(bodySpec);
+                when(bodySpec.contentType(any(MediaType.class))).thenReturn(bodySpec);
+                RestClient.ResponseSpec respSpec = mock(RestClient.ResponseSpec.class);
+
+                if (uri.contains("/oauth/token")) {
+                    when(bodySpec.body(any(String.class))).thenReturn(bodySpec);
+                    when(bodySpec.retrieve()).thenReturn(respSpec);
+                    when(respSpec.body(eq(Map.class))).thenReturn(Map.of("access_token", "admin-token"));
+                } else if (uri.contains("/oauth/keys/trusted")) {
+                    when(bodySpec.body(any(Map.class))).thenAnswer(bodyInv -> {
+                        capturedTrustedKeyBody.set(bodyInv.getArgument(0));
+                        return bodySpec;
+                    });
+                    if (trustedKeyPostShouldThrow409) {
+                        when(bodySpec.retrieve()).thenThrow(
+                                HttpClientErrorException.create(
+                                        HttpStatus.CONFLICT, "Conflict",
+                                        HttpHeaders.EMPTY,
+                                        "keyId owned by different tenant".getBytes(),
+                                        null));
+                    } else {
+                        when(bodySpec.retrieve()).thenReturn(respSpec);
+                        when(respSpec.body(eq(Map.class))).thenReturn(
+                                Map.of("validTo", "2026-06-16T00:00:00Z"));
+                    }
+                }
+                return bodySpec;
+            };
+            when(postSpec.uri(anyString())).thenAnswer(postUriAnswer);
+            when(postSpec.uri(anyString(), any(Object[].class))).thenAnswer(postUriAnswer);
+            return postSpec;
+        });
+
+        return restClient;
+    }
+}

--- a/src/test/java/com/java_template/common/auth/OboPropertiesTest.java
+++ b/src/test/java/com/java_template/common/auth/OboPropertiesTest.java
@@ -1,0 +1,109 @@
+package com.java_template.common.auth;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * ABOUTME: Verifies OBO encryption key resolution logic: env-var property takes precedence
+ * over file, file is used as fallback, and both-absent disables OBO.
+ */
+class OboPropertiesTest {
+
+    @Test
+    void resolveEncryptionKey_prefersPropertyOverFile(@TempDir Path tempDir) throws IOException {
+        Path keyFile = tempDir.resolve("key.txt");
+        Files.writeString(keyFile, "file-key-value");
+
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("property-key-value");
+        props.setEncryptionKeyFile(keyFile.toString());
+
+        assertThat(props.resolveEncryptionKey()).isEqualTo("property-key-value");
+    }
+
+    @Test
+    void resolveEncryptionKey_fallsBackToFile(@TempDir Path tempDir) throws IOException {
+        Path keyFile = tempDir.resolve("key.txt");
+        Files.writeString(keyFile, "  file-key-value  \n");
+
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("");
+        props.setEncryptionKeyFile(keyFile.toString());
+
+        assertThat(props.resolveEncryptionKey()).isEqualTo("file-key-value");
+    }
+
+    @Test
+    void resolveEncryptionKey_returnsNullWhenBothAbsent() {
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("");
+        props.setEncryptionKeyFile("/nonexistent/path/key.txt");
+
+        assertThat(props.resolveEncryptionKey()).isNull();
+    }
+
+    @Test
+    void resolveEncryptionKey_returnsNullWhenFileIsEmpty(@TempDir Path tempDir) throws IOException {
+        Path keyFile = tempDir.resolve("key.txt");
+        Files.writeString(keyFile, "   ");
+
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("");
+        props.setEncryptionKeyFile(keyFile.toString());
+
+        assertThat(props.resolveEncryptionKey()).isNull();
+    }
+
+    @Test
+    void isEnabled_returnsTrueWhenKeyResolvable(@TempDir Path tempDir) throws IOException {
+        Path keyFile = tempDir.resolve("key.txt");
+        Files.writeString(keyFile, "some-key");
+
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("");
+        props.setEncryptionKeyFile(keyFile.toString());
+
+        assertThat(props.isEnabled()).isTrue();
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void resolveEncryptionKey_returnsNullWhenFileIsUnreadable(@TempDir Path tempDir) throws IOException {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+                "POSIX file permissions not supported on this filesystem");
+
+        Path keyFile = tempDir.resolve("unreadable.txt");
+        Files.writeString(keyFile, "secret-key");
+        Files.setPosixFilePermissions(keyFile, PosixFilePermissions.fromString("---------"));
+
+        // Tests running as root can read any file regardless of permissions; skip in that case.
+        assumeTrue(!Files.isReadable(keyFile), "Test cannot run as root — file is still readable");
+
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("");
+        props.setEncryptionKeyFile(keyFile.toString());
+
+        assertThat(props.resolveEncryptionKey()).isNull();
+    }
+
+    @Test
+    void isEnabled_returnsFalseWhenNoKeyAvailable() {
+        OboProperties props = new OboProperties();
+        props.setEncryptionKey("");
+        props.setEncryptionKeyFile("/nonexistent/path");
+
+        assertThat(props.isEnabled()).isFalse();
+    }
+}

--- a/src/test/java/com/java_template/common/auth/OboTokenExceptionTest.java
+++ b/src/test/java/com/java_template/common/auth/OboTokenExceptionTest.java
@@ -1,0 +1,26 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Unit tests for OboTokenException.
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OboTokenExceptionTest {
+
+    @Test
+    void isRuntimeException() {
+        assertThat(new OboTokenException("msg")).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void preservesMessage() {
+        assertThat(new OboTokenException("test message").getMessage()).isEqualTo("test message");
+    }
+
+    @Test
+    void preservesCause() {
+        Throwable cause = new IllegalStateException("root");
+        assertThat(new OboTokenException("msg", cause).getCause()).isSameAs(cause);
+    }
+}

--- a/src/test/java/com/java_template/common/auth/OboTokenServiceTest.java
+++ b/src/test/java/com/java_template/common/auth/OboTokenServiceTest.java
@@ -1,0 +1,106 @@
+package com.java_template.common.auth;
+
+import com.java_template.common.config.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * ABOUTME: Verifies OboTokenService error handling for specific HTTP error responses
+ * from the Cyoda token exchange endpoint (403 tenant mismatch, 401 invalid subject token).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OboTokenServiceTest {
+
+    @Mock private SubjectTokenSigner subjectTokenSigner;
+    @Mock private Config config;
+
+    private OboTokenService service;
+    private HttpClientErrorException errorToThrow;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        OboProperties oboProperties = new OboProperties();
+        oboProperties.setEncryptionKey("BO1DMziwLVFBy+eBH4KSewhkCaPpP+2XTw018eTacho=");
+
+        when(config.getCyodaApiUrl()).thenReturn("http://cyoda.test/api");
+        when(config.getCyodaClientId()).thenReturn("client-id");
+        when(config.getCyodaClientSecret()).thenReturn("client-secret");
+        when(config.getTrustedHosts()).thenReturn(List.of());
+
+        when(subjectTokenSigner.sign(anyString(), any())).thenReturn("signed-subject-token");
+
+        service = new OboTokenService(oboProperties, subjectTokenSigner, config);
+
+        RestClient mockRestClient = buildMockRestClient();
+        Field restClientField = OboTokenService.class.getDeclaredField("restClient");
+        restClientField.setAccessible(true);
+        restClientField.set(service, mockRestClient);
+    }
+
+    @Test
+    void exchange_403_throwsTenantViolation() {
+        errorToThrow = HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN, "Forbidden",
+                HttpHeaders.EMPTY,
+                "{\"error\":\"access_denied\",\"error_description\":\"Tenant boundary violation\"}".getBytes(),
+                null);
+
+        assertThatThrownBy(() -> service.getOboToken("user-1", List.of("INVESTOR")))
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("tenant boundary violation")
+                .hasMessageContaining("user-1");
+    }
+
+    @Test
+    void exchange_401_throwsSigningKeyRotation() {
+        errorToThrow = HttpClientErrorException.create(
+                HttpStatus.UNAUTHORIZED, "Unauthorized",
+                HttpHeaders.EMPTY,
+                "{\"error\":\"invalid_grant\",\"error_description\":\"Subject token validation failed\"}".getBytes(),
+                null);
+
+        assertThatThrownBy(() -> service.getOboToken("user-1", List.of("INVESTOR")))
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("signing key may need rotation")
+                .hasMessageContaining("user-1");
+    }
+
+    private RestClient buildMockRestClient() {
+        RestClient restClient = mock(RestClient.class);
+
+        when(restClient.post()).thenAnswer(inv -> {
+            RestClient.RequestBodyUriSpec postSpec = mock(RestClient.RequestBodyUriSpec.class);
+            when(postSpec.uri(anyString())).thenAnswer(uriInv -> {
+                RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
+                when(bodySpec.header(anyString(), anyString())).thenReturn(bodySpec);
+                when(bodySpec.contentType(any(MediaType.class))).thenReturn(bodySpec);
+                when(bodySpec.body(any(String.class))).thenReturn(bodySpec);
+                when(bodySpec.retrieve()).thenThrow(errorToThrow);
+                return bodySpec;
+            });
+            return postSpec;
+        });
+
+        return restClient;
+    }
+}

--- a/src/test/java/com/java_template/common/auth/SubjectTokenSignerTest.java
+++ b/src/test/java/com/java_template/common/auth/SubjectTokenSignerTest.java
@@ -1,0 +1,99 @@
+package com.java_template.common.auth;
+
+// ABOUTME: Unit tests for SubjectTokenSigner RS256 JWT generation and key lifecycle.
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SubjectTokenSignerTest {
+
+    private SubjectTokenSigner signer;
+
+    @BeforeEach
+    void setUp() {
+        OboProperties props = new OboProperties();
+        props.setKeyId("test-key");
+        props.setIssuer("test-issuer");
+        props.setSubjectTokenTtlSeconds(300);
+        signer = new SubjectTokenSigner(props);
+    }
+
+    @Test
+    void sign_throwsOboTokenException_whenKeyNotLoaded() {
+        assertThatThrownBy(() -> signer.sign("user-1", List.of()))
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("not yet available");
+    }
+
+    @Test
+    void sign_throwsOboTokenException_whenCaasOrgIdNotLoaded() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        signer.setActiveKey((RSAPrivateKey) kpg.generateKeyPair().getPrivate());
+        // activeCaasOrgId not set
+        assertThatThrownBy(() -> signer.sign("user-1", List.of()))
+                .isInstanceOf(OboTokenException.class)
+                .hasMessageContaining("caas_org_id");
+    }
+
+    @Test
+    void sign_producesValidRs256JwtWithAllRequiredClaims() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        RSAPrivateKey key = (RSAPrivateKey) kpg.generateKeyPair().getPrivate();
+        signer.setActiveKey(key);
+        signer.setActiveCaasOrgId("test-org");
+
+        String token = signer.sign("user-uuid-1", List.of("INVESTOR", "ADMIN"));
+
+        SignedJWT jwt = SignedJWT.parse(token);
+        assertThat(jwt.getHeader().getAlgorithm()).isEqualTo(JWSAlgorithm.RS256);
+        assertThat(jwt.getHeader().getKeyID()).isEqualTo("test-key");
+        assertThat(jwt.getJWTClaimsSet().getSubject()).isEqualTo("user-uuid-1");
+        assertThat(jwt.getJWTClaimsSet().getIssuer()).isEqualTo("test-issuer");
+        assertThat(jwt.getJWTClaimsSet().getStringListClaim("user_roles"))
+                .containsExactly("INVESTOR", "ADMIN");
+        assertThat(jwt.getJWTClaimsSet().getStringClaim("caas_org_id")).isEqualTo("test-org");
+        assertThat(jwt.getJWTClaimsSet().getExpirationTime()).isAfter(new Date());
+    }
+
+    @Test
+    void isKeyLoaded_returnsFalse_beforeKeySet() {
+        assertThat(signer.isKeyLoaded()).isFalse();
+    }
+
+    @Test
+    void isKeyLoaded_returnsTrue_afterKeySet() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        RSAPrivateKey key = (RSAPrivateKey) kpg.generateKeyPair().getPrivate();
+        signer.setActiveKey(key);
+        assertThat(signer.isKeyLoaded()).isTrue();
+    }
+
+    @Test
+    void setActiveKey_updatesKeyAtomically() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        RSAPrivateKey key1 = (RSAPrivateKey) kpg.generateKeyPair().getPrivate();
+        RSAPrivateKey key2 = (RSAPrivateKey) kpg.generateKeyPair().getPrivate();
+
+        signer.setActiveKey(key1);
+        signer.setActiveCaasOrgId("test-org");
+        assertThat(signer.isKeyLoaded()).isTrue();
+
+        signer.setActiveKey(key2);
+        assertThatCode(() -> signer.sign("user-1", List.of())).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/java_template/common/config/CyodaLightConfigCustomizerTest.java
+++ b/src/test/java/com/java_template/common/config/CyodaLightConfigCustomizerTest.java
@@ -1,0 +1,64 @@
+package com.java_template.common.config;
+
+// ABOUTME: Verifies CyodaLightConfigCustomizer injects the correct property overrides
+// into the Spring Environment when the cyoda-light toggle is active.
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Verifies that CyodaLightConfigCustomizer installs a high-priority property source
+ * that rewrites app.config.* platform endpoints to target the cyoda-light sidecar
+ * whenever {@code app.config.cyoda-light.active=true}.
+ */
+class CyodaLightConfigCustomizerTest {
+
+    private final CyodaLightConfigCustomizer customizer = new CyodaLightConfigCustomizer();
+
+    @Test
+    void postProcessEnvironment_whenActive_overridesPlatformEndpointsWithDefaults() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("app.config.cyoda-light.active", "true");
+
+        customizer.postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getProperty("app.config.cyoda-api-url")).isEqualTo("http://cyoda-light:8080/api");
+        assertThat(environment.getProperty("app.config.grpc-address")).isEqualTo("cyoda-light");
+        assertThat(environment.getProperty("app.config.grpc-server-port", Integer.class)).isEqualTo(50051);
+        assertThat(environment.getProperty("app.config.skip-ssl", Boolean.class)).isTrue();
+        assertThat(environment.getProperty("app.config.ssl-trust-all", Boolean.class)).isTrue();
+    }
+
+    @Test
+    void postProcessEnvironment_whenActive_overridesPlatformEndpointsWithCustomValues() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("app.config.cyoda-light.active", "true");
+        environment.setProperty("app.config.cyoda-light.http-url", "http://my-custom-host:9090");
+        environment.setProperty("app.config.cyoda-light.grpc-host", "my-custom-host");
+        environment.setProperty("app.config.cyoda-light.grpc-port", "9999");
+
+        customizer.postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getProperty("app.config.cyoda-api-url")).isEqualTo("http://my-custom-host:9090/api");
+        assertThat(environment.getProperty("app.config.grpc-address")).isEqualTo("my-custom-host");
+        assertThat(environment.getProperty("app.config.grpc-server-port", Integer.class)).isEqualTo(9999);
+    }
+
+    @Test
+    void postProcessEnvironment_whenInactive_leavesEnvironmentUntouched() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("app.config.cyoda-api-url", "https://prod.cyoda.net/api");
+        environment.setProperty("app.config.grpc-address", "grpc-prod.cyoda.net");
+        environment.setProperty("app.config.grpc-server-port", "443");
+
+        customizer.postProcessEnvironment(environment, new SpringApplication());
+
+        assertThat(environment.getProperty("app.config.cyoda-api-url")).isEqualTo("https://prod.cyoda.net/api");
+        assertThat(environment.getProperty("app.config.grpc-address")).isEqualTo("grpc-prod.cyoda.net");
+        assertThat(environment.getProperty("app.config.grpc-server-port", Integer.class)).isEqualTo(443);
+        assertThat(environment.getPropertySources().contains("cyodaLightOverrides")).isFalse();
+    }
+}

--- a/src/test/java/com/java_template/common/exception/CyodaOperationExceptionTest.java
+++ b/src/test/java/com/java_template/common/exception/CyodaOperationExceptionTest.java
@@ -1,0 +1,46 @@
+package com.java_template.common.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ABOUTME: Tests for CyodaOperationException verifying message formatting,
+ * field accessors, and default retryable behavior.
+ */
+class CyodaOperationExceptionTest {
+
+    @Test
+    void messageIncludesCodeAndDetail() {
+        var ex = new CyodaOperationException("SERVER_ERROR", "something broke", true);
+
+        assertEquals("SERVER_ERROR", ex.getErrorCode());
+        assertEquals("something broke", ex.getErrorMessage());
+        assertTrue(ex.isRetryable());
+        assertTrue(ex.getMessage().contains("SERVER_ERROR"));
+        assertTrue(ex.getMessage().contains("something broke"));
+    }
+
+    @Test
+    void retryableDefaultsToFalseWhenNull() {
+        var ex = new CyodaOperationException("CLIENT_ERROR", "bad request", null);
+
+        assertFalse(ex.isRetryable());
+    }
+
+    @Test
+    void isRuntimeException() {
+        var ex = new CyodaOperationException("X", "msg", false);
+
+        assertInstanceOf(RuntimeException.class, ex);
+    }
+
+    @Test
+    void causeConstructorPreservesCause() {
+        var cause = new IllegalStateException("root problem");
+        var ex = new CyodaOperationException("PARSE_ERROR", "bad json", false, cause);
+
+        assertSame(cause, ex.getCause());
+        assertEquals("PARSE_ERROR", ex.getErrorCode());
+    }
+}

--- a/src/test/java/com/java_template/common/grpc/client/ClientAuthorizationInterceptorTest.java
+++ b/src/test/java/com/java_template/common/grpc/client/ClientAuthorizationInterceptorTest.java
@@ -1,0 +1,111 @@
+package com.java_template.common.grpc.client;
+
+// ABOUTME: Unit tests for ClientAuthorizationInterceptor OBO fail-fast and M2M pass-through behavior.
+
+import com.java_template.common.auth.Authentication;
+import com.java_template.common.auth.OboTokenException;
+import io.grpc.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.ClientAuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClientAuthorizationInterceptorTest {
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private ClientCall<Object, Object> clientCall;
+
+    @SuppressWarnings("unchecked")
+    private ClientCall.Listener<Object> listener;
+
+    private ClientAuthorizationInterceptor interceptor;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        interceptor = new ClientAuthorizationInterceptor(authentication);
+        listener = mock(ClientCall.Listener.class);
+        when(channel.newCall(any(), any())).thenReturn(clientCall);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void start_closesCallWithUnauthenticated_onOboTokenException() {
+        when(authentication.getAccessToken()).thenThrow(new OboTokenException("exchange failed"));
+
+        MethodDescriptor<Object, Object> method = buildMethod();
+        ClientCall<Object, Object> call = interceptor.interceptCall(method, CallOptions.DEFAULT, channel);
+        call.start(listener, new Metadata());
+
+        ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+        verify(listener).onClose(statusCaptor.capture(), any(Metadata.class));
+        assertThat(statusCaptor.getValue().getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+
+        // super.start() should NOT have been called on the underlying call
+        verify(clientCall, never()).start(any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void start_proceedsWithoutHeader_onClientAuthorizationException() {
+        when(authentication.getAccessToken())
+                .thenThrow(new ClientAuthorizationException(new OAuth2Error("access_denied"), "cyoda"));
+
+        MethodDescriptor<Object, Object> method = buildMethod();
+        ClientCall<Object, Object> call = interceptor.interceptCall(method, CallOptions.DEFAULT, channel);
+        call.start(listener, new Metadata());
+
+        // listener.onClose() should NOT have been called (call was not cancelled)
+        verify(listener, never()).onClose(any(), any());
+        // The call should still proceed via super.start()
+        verify(clientCall).start(eq(listener), any(Metadata.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void start_addsAuthorizationHeader_onSuccess() {
+        OAuth2AccessToken token = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, "valid-token",
+                Instant.now(), Instant.now().plusSeconds(3600));
+        when(authentication.getAccessToken()).thenReturn(token);
+
+        MethodDescriptor<Object, Object> method = buildMethod();
+        ClientCall<Object, Object> call = interceptor.interceptCall(method, CallOptions.DEFAULT, channel);
+        ArgumentCaptor<Metadata> headersCaptor = ArgumentCaptor.forClass(Metadata.class);
+        call.start(listener, new Metadata());
+
+        verify(clientCall).start(eq(listener), headersCaptor.capture());
+        Metadata capturedHeaders = headersCaptor.getValue();
+        String authValue = capturedHeaders.get(
+                Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER));
+        assertThat(authValue).isEqualTo("Bearer valid-token");
+    }
+
+    @SuppressWarnings("unchecked")
+    private MethodDescriptor<Object, Object> buildMethod() {
+        return MethodDescriptor.<Object, Object>newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName("test/TestMethod")
+                .setRequestMarshaller(mock(MethodDescriptor.Marshaller.class))
+                .setResponseMarshaller(mock(MethodDescriptor.Marshaller.class))
+                .build();
+    }
+}

--- a/src/test/java/com/java_template/common/grpc/client/event_handling/CloudEventParserTest.java
+++ b/src/test/java/com/java_template/common/grpc/client/event_handling/CloudEventParserTest.java
@@ -1,0 +1,46 @@
+package com.java_template.common.grpc.client.event_handling;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java_template.common.exception.CyodaOperationException;
+import io.cloudevents.v1.proto.CloudEvent;
+import org.cyoda.cloud.api.event.search.EntityResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for CloudEventParser verifying successful parsing returns
+ * the typed response directly, and parse failures throw CyodaOperationException.
+ */
+class CloudEventParserTest {
+
+    private final CloudEventParser parser = new CloudEventParser(new ObjectMapper());
+
+    @Test
+    void validJsonReturnsTypedResponse() {
+        String json = "{\"id\":\"test-id\",\"success\":true}";
+        CloudEvent event = CloudEvent.newBuilder()
+                .setTextData(json)
+                .build();
+
+        EntityResponse result = parser.parseCloudEvent(event, EntityResponse.class);
+
+        assertNotNull(result);
+        assertEquals("test-id", result.getId());
+    }
+
+    @Test
+    void invalidJsonThrowsCyodaOperationException() {
+        CloudEvent event = CloudEvent.newBuilder()
+                .setTextData("not valid json {{{")
+                .build();
+
+        CyodaOperationException ex = assertThrows(
+                CyodaOperationException.class,
+                () -> parser.parseCloudEvent(event, EntityResponse.class)
+        );
+
+        assertEquals("PARSE_ERROR", ex.getErrorCode());
+        assertFalse(ex.isRetryable());
+    }
+}

--- a/src/test/java/com/java_template/common/observability/GrpcObservabilityInterceptorTest.java
+++ b/src/test/java/com/java_template/common/observability/GrpcObservabilityInterceptorTest.java
@@ -1,0 +1,124 @@
+package com.java_template.common.observability;
+
+import io.grpc.*;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ABOUTME: Tests for GrpcObservabilityInterceptor — verifies that gRPC calls produce
+ * OpenTelemetry spans with method attributes and correct status tracking on close.
+ */
+class GrpcObservabilityInterceptorTest {
+
+    @RegisterExtension
+    static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+    private static final AttributeKey<String> RPC_METHOD_KEY = AttributeKey.stringKey("rpc.method");
+    private static final AttributeKey<Long> GRPC_STATUS_KEY = AttributeKey.longKey("rpc.grpc.status_code");
+
+    /** Minimal marshaller for using String as the gRPC request/response type in tests. */
+    private static class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+        @Override
+        public java.io.InputStream stream(String value) {
+            return new java.io.ByteArrayInputStream(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String parse(java.io.InputStream stream) {
+            try {
+                return new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            } catch (java.io.IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static final MethodDescriptor<String, String> TEST_METHOD = MethodDescriptor.<String, String>newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName("CloudEventsService/entityManage")
+            .setRequestMarshaller(new StringMarshaller())
+            .setResponseMarshaller(new StringMarshaller())
+            .build();
+
+    /**
+     * Channel that captures the listener passed to start() so tests can drive
+     * the call lifecycle by invoking onClose() directly.
+     */
+    private static class CapturingChannel extends Channel {
+        final AtomicReference<ClientCall.Listener<?>> capturedListener = new AtomicReference<>();
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions) {
+            return new ClientCall<>() {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    capturedListener.set(responseListener);
+                }
+                @Override public void request(int numMessages) {}
+                @Override public void cancel(String message, Throwable cause) {}
+                @Override public void halfClose() {}
+                @Override public void sendMessage(ReqT message) {}
+            };
+        }
+
+        @Override
+        public String authority() {
+            return "test-authority";
+        }
+    }
+
+    @Test
+    void shouldAddCustomAttributesToSpan() {
+        var interceptor = new GrpcObservabilityInterceptor(otelTesting.getOpenTelemetry());
+        var channel = new CapturingChannel();
+        var call = interceptor.interceptCall(TEST_METHOD, CallOptions.DEFAULT, channel);
+
+        call.start(new ClientCall.Listener<>() {}, new Metadata());
+
+        // Close with OK so the span ends and becomes visible in the test exporter
+        @SuppressWarnings("unchecked")
+        ClientCall.Listener<String> listener = (ClientCall.Listener<String>) channel.capturedListener.get();
+        assertNotNull(listener, "Listener should have been captured by CapturingChannel");
+        listener.onClose(Status.OK, new Metadata());
+
+        List<SpanData> spans = otelTesting.getSpans();
+        assertEquals(1, spans.size());
+
+        SpanData span = spans.get(0);
+        assertEquals("gRPC CloudEventsService/entityManage", span.getName());
+        assertEquals("CloudEventsService/entityManage", span.getAttributes().get(RPC_METHOD_KEY));
+    }
+
+    @Test
+    void shouldRecordGrpcStatusOnClose() {
+        var interceptor = new GrpcObservabilityInterceptor(otelTesting.getOpenTelemetry());
+        var channel = new CapturingChannel();
+        var call = interceptor.interceptCall(TEST_METHOD, CallOptions.DEFAULT, channel);
+
+        call.start(new ClientCall.Listener<>() {}, new Metadata());
+
+        // Simulate the server closing the call with DEADLINE_EXCEEDED
+        @SuppressWarnings("unchecked")
+        ClientCall.Listener<String> listener = (ClientCall.Listener<String>) channel.capturedListener.get();
+        assertNotNull(listener, "Listener should have been captured by CapturingChannel");
+        listener.onClose(Status.DEADLINE_EXCEEDED, new Metadata());
+
+        List<SpanData> spans = otelTesting.getSpans();
+        assertEquals(1, spans.size());
+
+        SpanData span = spans.get(0);
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        Long statusCode = span.getAttributes().get(GRPC_STATUS_KEY);
+        assertNotNull(statusCode);
+        assertEquals(Status.DEADLINE_EXCEEDED.getCode().value(), statusCode.intValue());
+    }
+}

--- a/src/test/java/com/java_template/common/observability/ObservableEventHandlerTest.java
+++ b/src/test/java/com/java_template/common/observability/ObservableEventHandlerTest.java
@@ -1,0 +1,162 @@
+package com.java_template.common.observability;
+
+import com.java_template.common.grpc.client.event_handling.EventHandler;
+import io.cloudevents.v1.proto.CloudEvent;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.metrics.data.MetricData;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ABOUTME: Tests for ObservableEventHandler — a decorator that wraps EventHandler
+ * with OpenTelemetry spans and metrics for CloudEvent processing observability.
+ */
+class ObservableEventHandlerTest {
+
+    @RegisterExtension
+    static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+    private static final AttributeKey<String> EVENT_TYPE_KEY = AttributeKey.stringKey("cyoda.event.type");
+    private static final AttributeKey<String> EVENT_ID_KEY = AttributeKey.stringKey("cyoda.event.id");
+
+    private CloudEvent buildTestEvent(String type, String id) {
+        return CloudEvent.newBuilder()
+                .setType(type)
+                .setId(id)
+                .setSource("test-source")
+                .build();
+    }
+
+    @Test
+    void shouldCreateSpanWithCorrectNameAndAttributes() {
+        var delegate = new RecordingEventHandler();
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+        var event = buildTestEvent("ENTITY_PROCESSOR_CALCULATION_REQUEST", "evt-001");
+
+        handler.handleEvent(event);
+
+        List<SpanData> spans = otelTesting.getSpans();
+        assertEquals(1, spans.size());
+
+        SpanData span = spans.get(0);
+        assertEquals("cyoda.event ENTITY_PROCESSOR_CALCULATION_REQUEST", span.getName());
+        assertEquals("ENTITY_PROCESSOR_CALCULATION_REQUEST", span.getAttributes().get(EVENT_TYPE_KEY));
+        assertEquals("evt-001", span.getAttributes().get(EVENT_ID_KEY));
+    }
+
+    @Test
+    void shouldDelegateToWrappedHandler() {
+        var delegate = new RecordingEventHandler();
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+        var event = buildTestEvent("ENTITY_PROCESSOR_CALCULATION_REQUEST", "evt-002");
+
+        handler.handleEvent(event);
+
+        assertEquals(1, delegate.eventsReceived.size());
+        assertEquals("evt-002", delegate.eventsReceived.get(0).getId());
+    }
+
+    @Test
+    void shouldMarkSpanAsErrorWhenDelegateThrows() {
+        var delegate = new ThrowingEventHandler(new RuntimeException("processor failed"));
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+        var event = buildTestEvent("ENTITY_PROCESSOR_CALCULATION_REQUEST", "evt-003");
+
+        assertThrows(RuntimeException.class, () -> handler.handleEvent(event));
+
+        List<SpanData> spans = otelTesting.getSpans();
+        assertEquals(1, spans.size());
+        assertEquals(StatusCode.ERROR, spans.get(0).getStatus().getStatusCode());
+        assertFalse(spans.get(0).getEvents().isEmpty(), "Should have exception event recorded");
+    }
+
+    @Test
+    void shouldDelegateSupportedTags() {
+        var delegate = new RecordingEventHandler();
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+
+        assertEquals(Set.of("test-tag"), handler.getSupportedTags());
+    }
+
+    @Test
+    void shouldRecordDurationMetricOnSuccess() {
+        var delegate = new RecordingEventHandler();
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+        var event = buildTestEvent("ENTITY_PROCESSOR_CALCULATION_REQUEST", "evt-005");
+
+        handler.handleEvent(event);
+
+        assertTrue(hasMetric("cyoda.event.duration"), "Should record duration histogram");
+    }
+
+    @Test
+    void shouldRecordEventCountOnSuccess() {
+        var delegate = new RecordingEventHandler();
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+        var event = buildTestEvent("ENTITY_PROCESSOR_CALCULATION_REQUEST", "evt-006");
+
+        handler.handleEvent(event);
+
+        assertTrue(hasMetric("cyoda.event.count"), "Should record event count");
+    }
+
+    @Test
+    void shouldRecordErrorCounterWhenDelegateThrows() {
+        var delegate = new ThrowingEventHandler(new RuntimeException("fail"));
+        var handler = new ObservableEventHandler(delegate, otelTesting.getOpenTelemetry());
+        var event = buildTestEvent("ENTITY_PROCESSOR_CALCULATION_REQUEST", "evt-007");
+
+        assertThrows(RuntimeException.class, () -> handler.handleEvent(event));
+
+        assertTrue(hasMetric("cyoda.event.errors"), "Should record error counter");
+    }
+
+    private boolean hasMetric(String name) {
+        Collection<MetricData> metrics = otelTesting.getMetrics();
+        return metrics.stream().anyMatch(m -> m.getName().equals(name));
+    }
+
+    // --- Test helpers ---
+
+    private static class RecordingEventHandler implements EventHandler {
+        final java.util.ArrayList<CloudEvent> eventsReceived = new java.util.ArrayList<>();
+
+        @Override
+        public void handleEvent(CloudEvent cloudEvent) {
+            eventsReceived.add(cloudEvent);
+        }
+
+        @Override
+        public Set<String> getSupportedTags() {
+            return Set.of("test-tag");
+        }
+    }
+
+    private static class ThrowingEventHandler implements EventHandler {
+        private final RuntimeException exception;
+
+        ThrowingEventHandler(RuntimeException exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public void handleEvent(CloudEvent cloudEvent) {
+            throw exception;
+        }
+
+        @Override
+        public Set<String> getSupportedTags() {
+            return Set.of();
+        }
+    }
+}

--- a/src/test/java/com/java_template/common/observability/StreamObservabilityListenerTest.java
+++ b/src/test/java/com/java_template/common/observability/StreamObservabilityListenerTest.java
@@ -1,0 +1,90 @@
+package com.java_template.common.observability;
+
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ABOUTME: Tests for StreamObservabilityListener — verifies that gRPC bidirectional
+ * stream lifecycle events are correctly tracked as OpenTelemetry gauge metrics for
+ * active streams, keep-alive age, and pending ACK counts.
+ */
+class StreamObservabilityListenerTest {
+
+    @RegisterExtension
+    static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+    private long readGauge(String metricName) {
+        List<MetricData> metrics = otelTesting.getMetrics();
+        return metrics.stream()
+                .filter(m -> m.getName().equals(metricName))
+                .findFirst()
+                .map(m -> {
+                    Collection<LongPointData> points = m.getLongGaugeData().getPoints();
+                    return points.stream()
+                            .mapToLong(LongPointData::getValue)
+                            .findFirst()
+                            .orElse(0L);
+                })
+                .orElse(0L);
+    }
+
+    @Test
+    void shouldIncrementActiveStreamsOnOpen() {
+        var listener = new StreamObservabilityListener(otelTesting.getOpenTelemetry());
+
+        listener.onStreamOpen();
+
+        assertEquals(1L, readGauge("cyoda.grpc.stream.active"));
+    }
+
+    @Test
+    void shouldDecrementActiveStreamsOnClose() {
+        var listener = new StreamObservabilityListener(otelTesting.getOpenTelemetry());
+
+        listener.onStreamOpen();
+        listener.onStreamClose();
+
+        assertEquals(0L, readGauge("cyoda.grpc.stream.active"));
+    }
+
+    @Test
+    void shouldDecrementActiveStreamsOnError() {
+        var listener = new StreamObservabilityListener(otelTesting.getOpenTelemetry());
+
+        listener.onStreamOpen();
+        listener.onStreamError();
+
+        assertEquals(0L, readGauge("cyoda.grpc.stream.active"));
+    }
+
+    @Test
+    void shouldTrackKeepAliveAge() {
+        var listener = new StreamObservabilityListener(otelTesting.getOpenTelemetry());
+
+        listener.onKeepAlive(System.currentTimeMillis());
+
+        long ageSeconds = readGauge("cyoda.grpc.keepalive.age");
+        assertTrue(ageSeconds >= 0 && ageSeconds <= 2,
+                "Keep-alive age should be near 0 seconds, but was: " + ageSeconds);
+    }
+
+    @Test
+    void shouldTrackPendingAcks() {
+        var listener = new StreamObservabilityListener(otelTesting.getOpenTelemetry());
+
+        listener.onEventSent();
+        listener.onEventSent();
+        listener.onAckReceived();
+
+        assertEquals(1L, readGauge("cyoda.grpc.ack.pending"));
+    }
+}

--- a/src/test/java/com/java_template/common/repository/CyodaRepositoryValidateResponseTest.java
+++ b/src/test/java/com/java_template/common/repository/CyodaRepositoryValidateResponseTest.java
@@ -1,0 +1,123 @@
+package com.java_template.common.repository;
+
+import com.java_template.common.exception.CyodaOperationException;
+import org.cyoda.cloud.api.event.common.Error;
+import org.cyoda.cloud.api.event.entity.EntityTransactionResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java_template.common.config.Config;
+import com.java_template.common.grpc.client.event_handling.CloudEventBuilder;
+import com.java_template.common.grpc.client.event_handling.CloudEventParser;
+import org.cyoda.cloud.api.grpc.CloudEventsServiceGrpc;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for CyodaRepository.validateResponse verifying that failed responses
+ * throw CyodaOperationException and warnings are logged without throwing.
+ */
+@ExtendWith(MockitoExtension.class)
+class CyodaRepositoryValidateResponseTest {
+
+    @Mock ObjectMapper objectMapper;
+    @Mock CloudEventsServiceGrpc.CloudEventsServiceBlockingStub stub;
+    @Mock CloudEventBuilder cloudEventBuilder;
+    @Mock CloudEventParser cloudEventParser;
+    @Mock Config config;
+
+    @InjectMocks CyodaRepository repository;
+
+    @Test
+    void successfulResponsePassesThrough() {
+        var response = new EntityTransactionResponse();
+        response.setSuccess(true);
+
+        EntityTransactionResponse result = repository.validateResponse(response);
+
+        assertSame(response, result);
+    }
+
+    @Test
+    void nullSuccessTreatedAsOk() {
+        var response = new EntityTransactionResponse();
+        response.setSuccess(null);
+
+        EntityTransactionResponse result = repository.validateResponse(response);
+
+        assertSame(response, result);
+    }
+
+    @Test
+    void failedResponseThrowsWithErrorDetails() {
+        var error = new Error();
+        error.setCode("SERVER_ERROR");
+        error.setMessage("disk full");
+        error.setRetryable(true);
+
+        var response = new EntityTransactionResponse();
+        response.setSuccess(false);
+        response.setError(error);
+
+        CyodaOperationException ex = assertThrows(
+                CyodaOperationException.class,
+                () -> repository.validateResponse(response)
+        );
+
+        assertEquals("SERVER_ERROR", ex.getErrorCode());
+        assertEquals("disk full", ex.getErrorMessage());
+        assertTrue(ex.isRetryable());
+    }
+
+    @Test
+    void failedResponseWithNoErrorObjectUsesDefaults() {
+        var response = new EntityTransactionResponse();
+        response.setSuccess(false);
+        response.setError(null);
+
+        CyodaOperationException ex = assertThrows(
+                CyodaOperationException.class,
+                () -> repository.validateResponse(response)
+        );
+
+        assertEquals("UNKNOWN", ex.getErrorCode());
+        assertFalse(ex.isRetryable());
+    }
+
+    @Test
+    void warningsDoNotCauseException() {
+        var response = new EntityTransactionResponse();
+        response.setSuccess(true);
+        response.setWarnings(List.of("deprecation notice", "slow query"));
+
+        EntityTransactionResponse result = repository.validateResponse(response);
+
+        assertSame(response, result);
+    }
+
+    @Test
+    void warningsLoggedEvenOnFailedResponse() {
+        var error = new Error();
+        error.setCode("FAIL");
+        error.setMessage("bad");
+        error.setRetryable(false);
+
+        var response = new EntityTransactionResponse();
+        response.setSuccess(false);
+        response.setError(error);
+        response.setWarnings(List.of("also this warning"));
+
+        CyodaOperationException ex = assertThrows(
+                CyodaOperationException.class,
+                () -> repository.validateResponse(response)
+        );
+
+        assertEquals("FAIL", ex.getErrorCode());
+    }
+}

--- a/src/test/java/com/java_template/common/serializer/ErrorInfoTest.java
+++ b/src/test/java/com/java_template/common/serializer/ErrorInfoTest.java
@@ -1,5 +1,6 @@
 package com.java_template.common.serializer;
 
+import com.java_template.common.serializer.ErrorInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/java_template/common/serializer/EvaluationChainTest.java
+++ b/src/test/java/com/java_template/common/serializer/EvaluationChainTest.java
@@ -576,28 +576,40 @@ class EvaluationChainTest {
     @Test
     @DisplayName("EvaluationChain should handle reason attachment strategies")
     void testReasonAttachmentStrategies() {
-        // Test with toWarnings strategy
         Function<CriterionSerializer.CriterionEvaluationContext, EvaluationOutcome> evaluator =
                 context -> EvaluationOutcome.Fail.businessRuleFailure("Business rule failed");
 
+        // Test with toReason strategy (default)
         EntityCriteriaCalculationResponse response1 = serializer.withRequest(request)
-                .withReasonAttachment(ReasonAttachmentStrategy.toWarnings())
+                .withReasonAttachment(ReasonAttachmentStrategy.toReason())
                 .evaluate(evaluator)
                 .complete();
 
         assertNotNull(response1);
         assertTrue(response1.getSuccess());
         assertFalse(response1.getMatches());
+        assertNotNull(response1.getReason());
+        assertTrue(response1.getReason().contains("Business rule failed"));
 
-        // Test with none strategy
+        // Test with toWarnings strategy
         EntityCriteriaCalculationResponse response2 = serializer.withRequest(request)
-                .withReasonAttachment(ReasonAttachmentStrategy.none())
+                .withReasonAttachment(ReasonAttachmentStrategy.toWarnings())
                 .evaluate(evaluator)
                 .complete();
 
         assertNotNull(response2);
         assertTrue(response2.getSuccess());
         assertFalse(response2.getMatches());
+
+        // Test with none strategy
+        EntityCriteriaCalculationResponse response3 = serializer.withRequest(request)
+                .withReasonAttachment(ReasonAttachmentStrategy.none())
+                .evaluate(evaluator)
+                .complete();
+
+        assertNotNull(response3);
+        assertTrue(response3.getSuccess());
+        assertFalse(response3.getMatches());
     }
 
     @Test

--- a/src/test/java/com/java_template/common/serializer/EvaluationOutcomeTest.java
+++ b/src/test/java/com/java_template/common/serializer/EvaluationOutcomeTest.java
@@ -1,5 +1,6 @@
 package com.java_template.common.serializer;
 
+import com.java_template.common.serializer.EvaluationOutcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/java_template/common/tool/CyodaInitConfigTest.java
+++ b/src/test/java/com/java_template/common/tool/CyodaInitConfigTest.java
@@ -1,11 +1,11 @@
 package com.java_template.common.tool;
 
 import com.beust.jcommander.JCommander;
+import com.java_template.common.tool.CyodaInitConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class for CyodaInitConfig to verify command line argument parsing

--- a/src/test/java/com/java_template/common/util/CyodaExceptionUtilTest.java
+++ b/src/test/java/com/java_template/common/util/CyodaExceptionUtilTest.java
@@ -1,13 +1,13 @@
 package com.java_template.common.util;
 
+import com.java_template.common.util.CyodaExceptionUtil;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for CyodaExceptionUtil to verify error message extraction from Cyoda backend exceptions.


### PR DESCRIPTION
## Summary

- **OBO auth**: Token service, key registration, subject signing, AES encryption, claims parser
- **Event auth context**: CloudEvent user identity propagation across gRPC events
- **OpenTelemetry observability**: gRPC interceptor, event handler, stream listener with auto-configuration
- **Entity access authorization**: `AccessRequest`, `EntityAccessAuthorizer`, `AllowAllEntityAccessAuthorizer`
- **Framework improvements**: `CyodaLightConfigCustomizer`, `CyodaOperationException`, updated gRPC event handling, connection monitoring, security config, repository validation
- **OpenAPI spec updates**: audit, IAM, common
- **Build**: New deps (OTel, oauth2-resource-server, logstash-logback-encoder, awaitility), validation tasks (`validateFunctionalRequirements`, `validateWorkflows`), OTel agent support
- **Tests**: Comprehensive coverage for all new framework code (auth, observability, config, repository, event handling)
- **Schemas**: Updated `EntityMetadata`, `EntityModelExportResponse`, `EntitySnapshotSearchResponse`
- **OBO resource paths** reverted to template convention (`/workflow/v1/obosigningkey.json`, `/entity-schemas/examples/OboSigningKey/`)

App-specific items intentionally skipped: Trino JDBC, bucket4j, condition/statemachine schemas, `ExternalizedFunctionConfig`, `ScheduledTransitionConfig`.

## Test plan

- [x] `./gradlew compileJava compileKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL (all tests pass)
- [ ] Merge into `cyoda-cloud-update`, then into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)